### PR TITLE
STORY-FIX-001: Fix agent creation to initialize last_seen timestamp

### DIFF
--- a/src/db/queries/agents.ts
+++ b/src/db/queries/agents.ts
@@ -28,9 +28,9 @@ export function createAgent(db: Database, input: CreateAgentInput): AgentRow {
   const now = new Date().toISOString();
 
   run(db, `
-    INSERT INTO agents (id, type, team_id, tmux_session, model, status, created_at, updated_at)
-    VALUES (?, ?, ?, ?, ?, 'idle', ?, ?)
-  `, [id, input.type, input.teamId || null, input.tmuxSession || null, input.model || null, now, now]);
+    INSERT INTO agents (id, type, team_id, tmux_session, model, status, created_at, updated_at, last_seen)
+    VALUES (?, ?, ?, ?, ?, 'idle', ?, ?, ?)
+  `, [id, input.type, input.teamId || null, input.tmuxSession || null, input.model || null, now, now, now]);
 
   return getAgentById(db, id)!;
 }


### PR DESCRIPTION
## Summary
- Fixed createAgent function to initialize last_seen timestamp on agent creation
- Previously agents were created with last_seen=NULL causing immediate stale detection

## Changes
- Added last_seen column to INSERT statement in createAgent()
- Set initial value to current timestamp (same as created_at)

## Test Plan
- ✅ All 21 existing tests passing
- Prevents agents from being marked stale immediately after creation

## Story
STORY-FIX-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)