### PR TITLE
STORY-INFRA-003: Scale QA agents to match PR queue depth

### DIFF
--- a/src/orchestrator/scheduler.ts
+++ b/src/orchestrator/scheduler.ts
@@ -2,7 +2,6 @@ import type { Database } from 'sql.js';
 import { getPlannedStories, updateStory, getStoryPointsByTeam, getStoryDependencies, type StoryRow } from '../db/queries/stories.js';
 import { getAgentsByTeam, getAgentById, createAgent, updateAgent, type AgentRow } from '../db/queries/agents.js';
 import { getTeamById, getAllTeams } from '../db/queries/teams.js';
-import { getMergeQueue } from '../db/queries/pull-requests.js';
 import { queryOne, queryAll } from '../db/client.js';
 import { createLog } from '../db/queries/logs.js';
 import { spawnTmuxSession, generateSessionName, isTmuxSessionRunning, sendToTmuxSession, startManager, isManagerRunning, getHiveSessions, waitForTmuxSessionReady } from '../tmux/manager.js';
@@ -371,43 +370,79 @@ export class Scheduler {
 
   /**
    * Check merge queue and spawn QA agents if needed
+   * Scales QA agents based on pending work: 1 QA per 2-3 pending PRs, max 5
    */
   async checkMergeQueue(): Promise<void> {
     const teams = getAllTeams(this.db);
 
     for (const team of teams) {
-      const queue = getMergeQueue(this.db, team.id);
-      if (queue.length === 0) continue;
+      await this.scaleQAAgents(team.id, team.name, team.repo_path);
+    }
+  }
 
-      // Check if there's an active QA agent for this team
-      const qaAgents = getAgentsByTeam(this.db, team.id)
-        .filter(a => a.type === 'qa' && a.status !== 'terminated');
+  /**
+   * Scale QA agents based on pending work
+   * - Count stories with status 'pr_submitted' or 'qa'
+   * - Calculate needed QA agents: 1 QA per 2-3 pending PRs, max 5
+   * - Spawn QA agents in parallel with unique session names
+   */
+  private async scaleQAAgents(teamId: string, teamName: string, repoPath: string): Promise<void> {
+    // Count pending QA work: stories in 'qa' or 'pr_submitted' status
+    const qaStories = queryAll<StoryRow>(this.db, `
+      SELECT * FROM stories
+      WHERE team_id = ? AND status IN ('qa', 'pr_submitted')
+    `, [teamId]);
 
-      if (qaAgents.length === 0) {
-        // Spawn a QA agent
-        try {
-          await this.spawnQA(team.id, team.name, team.repo_path);
-          createLog(this.db, {
-            agentId: 'scheduler',
-            eventType: 'QA_SPAWNED',
-            message: `Spawned QA agent for team ${team.name} (${queue.length} PRs in queue)`,
-            metadata: { teamId: team.id, queueLength: queue.length },
-          });
-        } catch {
-          // Log error but continue
-        }
+    const pendingCount = qaStories.length;
+    if (pendingCount === 0) return;
+
+    // Calculate needed QA agents: 1 per 2-3 pending PRs, max 5
+    const neededQAs = Math.min(Math.ceil(pendingCount / 2.5), 5);
+
+    // Get currently active QA agents for this team
+    const activeQAs = getAgentsByTeam(this.db, teamId)
+      .filter(a => a.type === 'qa' && a.status !== 'terminated');
+
+    const currentQACount = activeQAs.length;
+
+    if (neededQAs > currentQACount) {
+      // Scale up: spawn additional QA agents in parallel
+      const toSpawn = neededQAs - currentQACount;
+      const spawnPromises: Promise<AgentRow>[] = [];
+
+      for (let i = 0; i < toSpawn; i++) {
+        const index = currentQACount + i + 1;
+        spawnPromises.push(this.spawnQA(teamId, teamName, repoPath, index));
+      }
+
+      try {
+        await Promise.all(spawnPromises);
+        createLog(this.db, {
+          agentId: 'scheduler',
+          eventType: 'TEAM_SCALED_UP',
+          message: `Scaled QA agents for team ${teamName}: ${currentQACount} → ${neededQAs} (${pendingCount} pending stories)`,
+          metadata: { teamId, agentType: 'qa', previousCount: currentQACount, newCount: neededQAs, pendingCount },
+        });
+      } catch (err) {
+        createLog(this.db, {
+          agentId: 'scheduler',
+          eventType: 'AGENT_SPAWNED',
+          status: 'error',
+          message: `Failed to scale QA agents for team ${teamName}: ${err instanceof Error ? err.message : 'Unknown error'}`,
+          metadata: { teamId, agentType: 'qa', error: String(err) },
+        });
       }
     }
   }
 
-  private async spawnQA(teamId: string, teamName: string, repoPath: string): Promise<AgentRow> {
+  private async spawnQA(teamId: string, teamName: string, repoPath: string, index: number = 1): Promise<AgentRow> {
     const agent = createAgent(this.db, {
       type: 'qa',
       teamId,
       model: 'sonnet',
     });
 
-    const sessionName = generateSessionName('qa', teamName);
+    const sessionName = generateSessionName('qa', teamName, index);
     const workDir = `${this.config.rootDir}/${repoPath}`;
 
     if (!await isTmuxSessionRunning(sessionName)) {


### PR DESCRIPTION
## Summary
Implements dynamic QA agent scaling based on PR queue depth. Previously only one QA agent was spawned per team. Now the scheduler automatically scales QA agents based on pending work.

## Changes
- **Modified `checkMergeQueue()`**: Iterates through teams and calls new `scaleQAAgents()` method
- **Added `scaleQAAgents()` method**:
  - Counts stories with status 'qa' or 'pr_submitted'
  - Calculates needed QA agents: 1 per 2-3 pending PRs, max 5 agents
  - Spawns multiple QA agents in parallel using `Promise.all()`
  - Each QA gets unique index for session naming
- **Modified `spawnQA()`**: Added optional `index` parameter (default 1)
  - Generates unique tmux session names: `hive-qa-<team>-1`, `hive-qa-<team>-2`, etc.
- **Cleanup**: Removed unused `getMergeQueue` import, fixed event types

## Scaling Formula
- **Pending count**: Stories with status 'qa' OR 'pr_submitted'
- **QA agents needed**: `Math.min(Math.ceil(pendingCount / 2.5), 5)`
- **Examples**:
  - 1-2 pending → 1 QA agent
  - 3-5 pending → 2 QA agents
  - 6-8 pending → 3 QA agents
  - 13+ pending → 5 QA agents (max)

## Implementation Details
- QA agents spawn in parallel for efficiency
- Each agent gets unique DB record with type='qa'
- Unique tmux session names generated using existing `generateSessionName()` utility
- Logs scaling operations with `TEAM_SCALED_UP` event type
- Health checks and manager integration work with multiple QAs

## Test Plan
- [ ] Create multiple stories and mark them as 'qa' or 'pr_submitted'
- [ ] Run scheduler's `checkMergeQueue()` method
- [ ] Verify correct number of QA agents spawn based on pending count
- [ ] Verify each QA has unique tmux session name (hive-qa-team-N)
- [ ] Check that agents are registered in DB with type='qa'
- [ ] Verify scaling caps at 5 QA agents maximum

🤖 Generated with [Claude Code](https://claude.com/claude-code)