### PR TITLE
STORY-INFRA-001: Add git worktree support for parallel agent isolation

### DIFF
--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -215,10 +215,24 @@ agentsCommand
         return;
       }
 
-      // Delete terminated agents
+      // Delete terminated agents and their worktrees
       let deleted = 0;
       for (const agent of terminatedAgents) {
         try {
+          // Remove worktree if exists
+          if (agent.worktree_path) {
+            try {
+              const { execSync } = await import('child_process');
+              const fullWorktreePath = `${root}/${agent.worktree_path}`;
+              execSync(`git worktree remove "${fullWorktreePath}" --force`, {
+                cwd: root,
+                stdio: 'pipe',
+              });
+            } catch (err) {
+              console.error(chalk.yellow(`Warning: Failed to remove worktree for ${agent.id}: ${err instanceof Error ? err.message : 'Unknown error'}`));
+            }
+          }
+
           deleteAgent(db.db, agent.id);
           deleted++;
         } catch (err) {

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -337,6 +337,21 @@ function runMigrations(db: SqlJsDatabase): void {
     }
     db.run("INSERT INTO migrations (name) VALUES ('005-add-agent-last-seen.sql')");
   }
+
+  // Migration 006: Add worktree_path column to agents for git worktree isolation
+  const result006 = db.exec("SELECT name FROM migrations WHERE name = '006-add-agent-worktree.sql'");
+  const migration006Applied = result006.length > 0 && result006[0].values.length > 0;
+
+  if (!migration006Applied) {
+    const columns = db.exec("PRAGMA table_info(agents)");
+    const hasWorktreePathColumn = columns.length > 0 &&
+      columns[0].values.some((col: unknown[]) => col[1] === 'worktree_path');
+
+    if (!hasWorktreePathColumn) {
+      db.run("ALTER TABLE agents ADD COLUMN worktree_path TEXT");
+    }
+    db.run("INSERT INTO migrations (name) VALUES ('006-add-agent-worktree.sql')");
+  }
 }
 
 export async function getDatabase(hiveDir: string): Promise<DatabaseClient> {
@@ -389,6 +404,7 @@ export interface AgentRow {
   memory_state: string | null;
   last_seen: string | null;
   cli_tool: string;
+  worktree_path: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/src/db/queries/agents.ts
+++ b/src/db/queries/agents.ts
@@ -12,6 +12,7 @@ export interface CreateAgentInput {
   teamId?: string | null;
   tmuxSession?: string | null;
   model?: string | null;
+  worktreePath?: string | null;
 }
 
 export interface UpdateAgentInput {
@@ -19,6 +20,7 @@ export interface UpdateAgentInput {
   tmuxSession?: string | null;
   currentStoryId?: string | null;
   memoryState?: string | null;
+  worktreePath?: string | null;
 }
 
 export function createAgent(db: Database, input: CreateAgentInput): AgentRow {
@@ -28,9 +30,9 @@ export function createAgent(db: Database, input: CreateAgentInput): AgentRow {
   const now = new Date().toISOString();
 
   run(db, `
-    INSERT INTO agents (id, type, team_id, tmux_session, model, status, created_at, updated_at, last_seen)
-    VALUES (?, ?, ?, ?, ?, 'idle', ?, ?, ?)
-  `, [id, input.type, input.teamId || null, input.tmuxSession || null, input.model || null, now, now, now]);
+    INSERT INTO agents (id, type, team_id, tmux_session, model, status, worktree_path, created_at, updated_at, last_seen)
+    VALUES (?, ?, ?, ?, ?, 'idle', ?, ?, ?, ?)
+  `, [id, input.type, input.teamId || null, input.tmuxSession || null, input.model || null, input.worktreePath || null, now, now, now]);
 
   return getAgentById(db, id)!;
 }
@@ -86,6 +88,10 @@ export function updateAgent(db: Database, id: string, input: UpdateAgentInput): 
   if (input.memoryState !== undefined) {
     updates.push('memory_state = ?');
     values.push(input.memoryState);
+  }
+  if (input.worktreePath !== undefined) {
+    updates.push('worktree_path = ?');
+    values.push(input.worktreePath);
   }
 
   if (updates.length === 1) {


### PR DESCRIPTION
## Summary

Implements STORY-INFRA-001 to fix the issue where multiple agents working on the same team share one git working directory and clobber each other's branches. Each agent now gets an isolated git worktree.

## Changes

### Database Migration
- Added migration 006 to add `worktree_path` column to agents table
- Updated `AgentRow` interface to include `worktree_path` field
- Updated `CreateAgentInput` and `UpdateAgentInput` interfaces

### Scheduler (src/orchestrator/scheduler.ts)
- Added `createWorktree()` helper method to create git worktrees
- Worktree path format: `repos/<team-id>-<agent-id>/`
- Branch name format: `agent/<agent-id>`
- Updated all spawn methods (spawnQA, spawnSenior, spawnIntermediate, spawnJunior) to:
  - Create worktree before spawning tmux session
  - Pass worktree path as workDir instead of team repo path
  - Store worktree_path in agent record
- Added `removeWorktree()` helper method
- Updated health check to remove worktrees when terminating agents

### Scaler (src/orchestrator/scaler.ts)
- Added `rootDir` to `ScalerConfig`
- Updated `terminateAgent()` to remove worktrees before marking agent as terminated

### Cleanup Command (src/cli/commands/agents.ts)
- Updated `hive agents cleanup` command to remove worktrees for terminated agents

## Testing

The implementation follows existing patterns in the codebase:
- Database migration follows the same pattern as migrations 002-005
- Git commands use `execSync` with proper error handling
- Worktree removal uses `--force` flag to handle edge cases
- All termination flows now include worktree cleanup

## Impact

- **Parallel Agent Safety**: Agents can now work in parallel without conflicts
- **Resource Management**: Worktrees are automatically cleaned up when agents terminate
- **Backward Compatible**: Existing agents without worktree_path will continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)