### PR TITLE
STORY-FIX-007: Ensure agent prompts auto-submit after tmux send-keys

### DIFF
--- a/src/tmux/manager.ts
+++ b/src/tmux/manager.ts
@@ -134,7 +134,8 @@ export async function sendToTmuxSession(sessionName: string, text: string, clear
         // Use send-keys with literal flag to handle special characters
         // '--' signals end of options, preventing lines starting with '-' from being parsed as flags
         await execa('tmux', ['send-keys', '-t', sessionName, '-l', '--', line]);
-        await execa('tmux', ['send-keys', '-t', sessionName, 'Enter']);
+        // Send Enter as a key event, not as literal text, to ensure prompt receives it
+        await execa('tmux', ['send-keys', '-t', sessionName, 'C-m']);
         // Small delay between lines to ensure they're processed
         await new Promise(resolve => setTimeout(resolve, 100));
       }
@@ -143,7 +144,8 @@ export async function sendToTmuxSession(sessionName: string, text: string, clear
     // For single-line text, use send-keys with literal flag then Enter separately
     // '--' signals end of options, preventing text starting with '-' from being parsed as flags
     await execa('tmux', ['send-keys', '-t', sessionName, '-l', '--', text]);
-    await execa('tmux', ['send-keys', '-t', sessionName, 'Enter']);
+    // Send Enter as a key event (C-m = carriage return = Enter) to ensure prompt receives it
+    await execa('tmux', ['send-keys', '-t', sessionName, 'C-m']);
   }
 }
 


### PR DESCRIPTION
## Summary
Replace literal 'Enter' string with 'C-m' (carriage return) key event when submitting commands to tmux sessions. This ensures the prompt properly receives the Enter signal across all shell environments.

## Problem
When spawning agents or sending nudges via tmux send-keys, the prompt text often ends up in the input buffer instead of being submitted. This is caused by using literal 'Enter' strings instead of actual key events.

## Solution
Updated `sendToTmuxSession()` to use 'C-m' (carriage return) key event instead of literal 'Enter' strings, which is consistent with the existing `sendEnterToTmuxSession()` implementation.

## Changes
- sendToTmuxSession() now uses 'C-m' for line submission (both single-line and multi-line cases)
- Added comments explaining the fix
- More reliable prompt handling across different shell environments

## Test Results
- All 124 tests passing ✓
- No test regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)