### PR TITLE
STORY-FIX-005: Prevent duplicate agents on same tmux session

### DIFF
--- a/src/orchestrator/scheduler.ts
+++ b/src/orchestrator/scheduler.ts
@@ -610,6 +610,15 @@ export class Scheduler {
   }
 
   private async spawnSenior(teamId: string, teamName: string, repoPath: string, index?: number): Promise<AgentRow> {
+    const sessionName = generateSessionName('senior', teamName, index);
+
+    // Prevent creating duplicate agents on same tmux session
+    const existingSeniors = getAgentsByTeam(this.db, teamId).filter(a => a.type === 'senior');
+    const existingOnSession = existingSeniors.find(a => a.tmux_session === sessionName && a.status !== 'terminated');
+    if (existingOnSession && await isTmuxSessionRunning(sessionName)) {
+      return existingOnSession;
+    }
+
     const agent = createAgent(this.db, {
       type: 'senior',
       teamId,
@@ -619,8 +628,6 @@ export class Scheduler {
     // Create git worktree for this agent
     const worktreePath = await this.createWorktree(agent.id, teamId, repoPath);
     const workDir = `${this.config.rootDir}/${worktreePath}`;
-
-    const sessionName = generateSessionName('senior', teamName, index);
 
     if (!await isTmuxSessionRunning(sessionName)) {
       // Build CLI command using the configured runtime for Senior agents
@@ -662,6 +669,13 @@ export class Scheduler {
   private async spawnIntermediate(teamId: string, teamName: string, repoPath: string): Promise<AgentRow> {
     const existing = getAgentsByTeam(this.db, teamId).filter(a => a.type === 'intermediate');
     const index = existing.length + 1;
+    const sessionName = generateSessionName('intermediate', teamName, index);
+
+    // Prevent creating duplicate agents on same tmux session
+    const existingOnSession = existing.find(a => a.tmux_session === sessionName && a.status !== 'terminated');
+    if (existingOnSession && await isTmuxSessionRunning(sessionName)) {
+      return existingOnSession;
+    }
 
     const agent = createAgent(this.db, {
       type: 'intermediate',
@@ -672,8 +686,6 @@ export class Scheduler {
     // Create git worktree for this agent
     const worktreePath = await this.createWorktree(agent.id, teamId, repoPath);
     const workDir = `${this.config.rootDir}/${worktreePath}`;
-
-    const sessionName = generateSessionName('intermediate', teamName, index);
 
     if (!await isTmuxSessionRunning(sessionName)) {
       // Build CLI command using the configured runtime for Intermediate agents
@@ -714,6 +726,13 @@ export class Scheduler {
   private async spawnJunior(teamId: string, teamName: string, repoPath: string): Promise<AgentRow> {
     const existing = getAgentsByTeam(this.db, teamId).filter(a => a.type === 'junior');
     const index = existing.length + 1;
+    const sessionName = generateSessionName('junior', teamName, index);
+
+    // Prevent creating duplicate agents on same tmux session
+    const existingOnSession = existing.find(a => a.tmux_session === sessionName && a.status !== 'terminated');
+    if (existingOnSession && await isTmuxSessionRunning(sessionName)) {
+      return existingOnSession;
+    }
 
     const agent = createAgent(this.db, {
       type: 'junior',
@@ -724,8 +743,6 @@ export class Scheduler {
     // Create git worktree for this agent
     const worktreePath = await this.createWorktree(agent.id, teamId, repoPath);
     const workDir = `${this.config.rootDir}/${worktreePath}`;
-
-    const sessionName = generateSessionName('junior', teamName, index);
 
     if (!await isTmuxSessionRunning(sessionName)) {
       // Build CLI command using the configured runtime for Junior agents


### PR DESCRIPTION
## Summary
- Adds duplicate agent prevention checks to `spawnSenior`, `spawnIntermediate`, and `spawnJunior` in scheduler.ts
- Before creating a new agent, checks if a non-terminated agent already exists on the target tmux session
- If a live agent is found, returns it instead of creating a duplicate DB record

## Test plan
- [ ] Run `hive assign` multiple times and verify no duplicate agents are created
- [ ] Verify existing agents are returned when session is already running

🤖 Generated with [Claude Code](https://claude.com/claude-code)