### PR TITLE
feat: Add npm publish step to release workflow (STORY-REL-004)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,12 +34,18 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
       - name: Build
         run: npm run build
+
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create tarball
         run: npm pack

--- a/package.json
+++ b/package.json
@@ -71,5 +71,8 @@
     "agile",
     "development"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
## Summary
- Adds npm publishing to the release-please GitHub Actions workflow
- Configures npm registry authentication using NPM_TOKEN secret
- Adds publishConfig to package.json for public access

## Changes
1. **package.json**: Added `publishConfig` with `access: "public"`
2. **.github/workflows/release-please.yml**: 
   - Added `registry-url` to setup-node action
   - Added npm publish step with NODE_AUTH_TOKEN environment variable
   - Publish only runs when release_created is true (existing condition)

## Test plan
- [x] Linting passes (`npm run lint`)
- [x] Type checking passes (`npm run type-check`)
- [x] All tests pass (`npm test`)
- [ ] Verify NPM_TOKEN secret is configured in GitHub repository settings
- [ ] Test npm publish on next release

## Dependencies
- Blocks STORY-REL-005 (README update depends on npm publish being enabled)

Implements STORY-REL-004

🤖 Generated with [Claude Code](https://claude.com/claude-code)