### PR TITLE
Story STORY-IMP-008: Update default model IDs to latest Claude versions

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -13,21 +13,21 @@ describe('HiveConfigSchema', () => {
       models: {
         tech_lead: {
           provider: 'anthropic',
-          model: 'claude-opus-4-20250514',
+          model: 'claude-opus-4-6',
           max_tokens: 16000,
           temperature: 0.7,
           cli_tool: 'claude',
         },
         senior: {
           provider: 'anthropic',
-          model: 'claude-sonnet-4-20250514',
+          model: 'claude-sonnet-4-5-20250929',
           max_tokens: 8000,
           temperature: 0.5,
           cli_tool: 'claude',
         },
         intermediate: {
           provider: 'anthropic',
-          model: 'claude-haiku-3-5-20241022',
+          model: 'claude-haiku-4-5-20251001',
           max_tokens: 4000,
           temperature: 0.3,
           cli_tool: 'claude',
@@ -41,7 +41,7 @@ describe('HiveConfigSchema', () => {
         },
         qa: {
           provider: 'anthropic',
-          model: 'claude-sonnet-4-20250514',
+          model: 'claude-sonnet-4-5-20250929',
           max_tokens: 8000,
           temperature: 0.2,
           cli_tool: 'claude',

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -13,21 +13,21 @@ const ModelConfigSchema = z.object({
 const ModelsConfigSchema = z.object({
   tech_lead: ModelConfigSchema.default({
     provider: 'anthropic',
-    model: 'claude-opus-4-20250514',
+    model: 'claude-opus-4-6',
     max_tokens: 16000,
     temperature: 0.7,
     cli_tool: 'claude',
   }),
   senior: ModelConfigSchema.default({
     provider: 'anthropic',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-5-20250929',
     max_tokens: 8000,
     temperature: 0.5,
     cli_tool: 'claude',
   }),
   intermediate: ModelConfigSchema.default({
     provider: 'anthropic',
-    model: 'claude-haiku-3-5-20241022',
+    model: 'claude-haiku-4-5-20251001',
     max_tokens: 4000,
     temperature: 0.3,
     cli_tool: 'claude',
@@ -41,7 +41,7 @@ const ModelsConfigSchema = z.object({
   }),
   qa: ModelConfigSchema.default({
     provider: 'anthropic',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-5-20250929',
     max_tokens: 8000,
     temperature: 0.2,
     cli_tool: 'claude',
@@ -147,7 +147,7 @@ version: "1.0"
 models:
   tech_lead:
     provider: anthropic
-    model: claude-opus-4-20250514
+    model: claude-opus-4-6
     max_tokens: 16000
     temperature: 0.7
     # CLI tool used to spawn agents (claude, codex, or gemini)
@@ -155,14 +155,14 @@ models:
 
   senior:
     provider: anthropic
-    model: claude-sonnet-4-20250514
+    model: claude-sonnet-4-5-20250929
     max_tokens: 8000
     temperature: 0.5
     cli_tool: claude
 
   intermediate:
     provider: anthropic
-    model: claude-haiku-3-5-20241022
+    model: claude-haiku-4-5-20251001
     max_tokens: 4000
     temperature: 0.3
     cli_tool: claude
@@ -176,7 +176,7 @@ models:
 
   qa:
     provider: anthropic
-    model: claude-sonnet-4-20250514
+    model: claude-sonnet-4-5-20250929
     max_tokens: 8000
     temperature: 0.2
     cli_tool: claude


### PR DESCRIPTION
## Summary
Updated default model IDs in the configuration schema to use the latest Claude models:
- claude-opus-4-20250514 → claude-opus-4-6
- claude-sonnet-4-20250514 → claude-sonnet-4-5-20250929  
- claude-haiku-3-5-20241022 → claude-haiku-4-5-20251001

## Changes
- Updated model IDs in `src/config/schema.ts` (both schema defaults and YAML generation)
- Updated test fixtures in `src/config/schema.test.ts`
- All tests passing (127 tests)
- Build successful

## Test plan
- ✅ All schema validation tests pass
- ✅ Default config generation tests pass
- ✅ Config parsing with updated models tests pass
- ✅ Full build completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)