### PR TITLE
fix: change versionMap from let to const to fix linting error

### DIFF
--- a/src/cli/dashboard/panels/agents.ts
+++ b/src/cli/dashboard/panels/agents.ts
@@ -95,7 +95,7 @@ export async function updateAgentsPanel(list: Widgets.ListElement, db: Database)
   debugLog(`updateAgentsPanel called, found ${agents.length} agents, currentSelection=${currentSelection}`);
 
   // Load config to get model version info
-  let versionMap: Record<string, string> = {};
+  const versionMap: Record<string, string> = {};
   try {
     const root = findHiveRoot();
     if (root) {


### PR DESCRIPTION
## Summary
Fixes ESLint linting error that was blocking all PRs in the merge queue.

## Changes
- Changed `versionMap` declaration from `let` to `const` in `src/cli/dashboard/panels/agents.ts`

## Issue
The variable was declared with `let` but never reassigned, causing:
```
error  'versionMap' is never reassigned. Use 'const' instead  prefer-const
```

This was causing all PRs to fail the build step in CI.

## Test plan
- [x] Linting passes locally with `npm run lint`
- [x] No functional changes - purely fixing code style

🤖 Generated with Claude Code