### PR TITLE
Story STORY-IMP-008: Update default model IDs to latest Claude versions

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -13,21 +13,21 @@ describe('HiveConfigSchema', () => {
       models: {
         tech_lead: {
           provider: 'anthropic',
-          model: 'claude-opus-4-20250514',
+          model: 'claude-opus-4-6',
           max_tokens: 16000,
           temperature: 0.7,
           cli_tool: 'claude',
         },
         senior: {
           provider: 'anthropic',
-          model: 'claude-sonnet-4-20250514',
+          model: 'claude-sonnet-4-5-20250929',
           max_tokens: 8000,
           temperature: 0.5,
           cli_tool: 'claude',
         },
         intermediate: {
           provider: 'anthropic',
-          model: 'claude-haiku-3-5-20241022',
+          model: 'claude-haiku-4-5-20251001',
           max_tokens: 4000,
           temperature: 0.3,
           cli_tool: 'claude',
@@ -41,7 +41,7 @@ describe('HiveConfigSchema', () => {
         },
         qa: {
           provider: 'anthropic',
-          model: 'claude-sonnet-4-20250514',
+          model: 'claude-sonnet-4-5-20250929',
           max_tokens: 8000,
           temperature: 0.2,
           cli_tool: 'claude',

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -13,21 +13,21 @@ const ModelConfigSchema = z.object({
 const ModelsConfigSchema = z.object({
   tech_lead: ModelConfigSchema.default({
     provider: 'anthropic',
-    model: 'claude-opus-4-20250514',
+    model: 'claude-opus-4-6',
     max_tokens: 16000,
     temperature: 0.7,
     cli_tool: 'claude',
   }),
   senior: ModelConfigSchema.default({
     provider: 'anthropic',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-5-20250929',
     max_tokens: 8000,
     temperature: 0.5,
     cli_tool: 'claude',
   }),
   intermediate: ModelConfigSchema.default({
     provider: 'anthropic',
-    model: 'claude-haiku-3-5-20241022',
+    model: 'claude-haiku-4-5-20251001',
     max_tokens: 4000,
     temperature: 0.3,
     cli_tool: 'claude',
@@ -41,7 +41,7 @@ const ModelsConfigSchema = z.object({
   }),
   qa: ModelConfigSchema.default({
     provider: 'anthropic',
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-5-20250929',
     max_tokens: 8000,
     temperature: 0.2,
     cli_tool: 'claude',
@@ -147,7 +147,7 @@ version: "1.0"
 models:
   tech_lead:
     provider: anthropic
-    model: claude-opus-4-20250514
+    model: claude-opus-4-6
     max_tokens: 16000
     temperature: 0.7
     # CLI tool used to spawn agents (claude, codex, or gemini)
@@ -155,14 +155,14 @@ models:
 
   senior:
     provider: anthropic
-    model: claude-sonnet-4-20250514
+    model: claude-sonnet-4-5-20250929
     max_tokens: 8000
     temperature: 0.5
     cli_tool: claude
 
   intermediate:
     provider: anthropic
-    model: claude-haiku-3-5-20241022
+    model: claude-haiku-4-5-20251001
     max_tokens: 4000
     temperature: 0.3
     cli_tool: claude
@@ -176,7 +176,7 @@ models:
 
   qa:
     provider: anthropic
-    model: claude-sonnet-4-20250514
+    model: claude-sonnet-4-5-20250929
     max_tokens: 8000
     temperature: 0.2
     cli_tool: claude


### PR DESCRIPTION
Updated configuration schema to use the latest Claude models (Opus 4.6, Sonnet 4.5, Haiku 4.5). All tests passing.