### PR TITLE
fix: use prepared statements in heartbeat test to fix build

### DIFF
--- a/src/db/queries/heartbeat.test.ts
+++ b/src/db/queries/heartbeat.test.ts
@@ -32,8 +32,12 @@ describe('heartbeat queries', () => {
 
       updateAgentHeartbeat(db, agent.id);
 
-      const afterUpdate = db.exec(`SELECT last_seen FROM agents WHERE id = ?`, [agent.id]);
-      const updatedLastSeen = afterUpdate[0]?.values[0]?.[0];
+      const stmt = db.prepare(`SELECT last_seen FROM agents WHERE id = ?`);
+      stmt.bind([agent.id]);
+      const afterUpdate = [];
+      while (stmt.step()) afterUpdate.push(stmt.getAsObject());
+      stmt.free();
+      const updatedLastSeen = afterUpdate[0]?.last_seen;
 
       expect(updatedLastSeen).toBeDefined();
       expect(typeof updatedLastSeen).toBe('string');
@@ -49,8 +53,12 @@ describe('heartbeat queries', () => {
       updateAgentHeartbeat(db, agent.id);
       updateAgentHeartbeat(db, agent.id);
 
-      const result = db.exec(`SELECT last_seen FROM agents WHERE id = ?`, [agent.id]);
-      const lastSeen = result[0]?.values[0]?.[0];
+      const stmtResult = db.prepare(`SELECT last_seen FROM agents WHERE id = ?`);
+      stmtResult.bind([agent.id]);
+      const result = [];
+      while (stmtResult.step()) result.push(stmtResult.getAsObject());
+      stmtResult.free();
+      const lastSeen = result[0]?.last_seen;
 
       expect(lastSeen).toBeDefined();
     });


### PR DESCRIPTION
## Summary
- Main branch build is broken due to `heartbeat.test.ts` calling `db.exec()` with 2 arguments (sql.js only accepts 1)
- Replaced with `db.prepare()` + `stmt.bind()` pattern which properly supports parameterized queries
- Also fixed result access pattern from `exec()` format (`.values[0][0]`) to `getAsObject()` format (`.last_seen`)

## Test plan
- [x] `npm run build` passes locally
- [ ] CI build should pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)