### PR TITLE
feat: auto-merge approved PRs immediately

### DIFF
--- a/src/orchestrator/scheduler.ts
+++ b/src/orchestrator/scheduler.ts
@@ -205,12 +205,12 @@ export class Scheduler {
    * Calculate queue depth for an agent (number of active stories)
    */
   private getAgentWorkload(agentId: string): number {
-    const activeStories = queryAll<StoryRow>(this.db, `
-      SELECT * FROM stories
+    const result = queryOne<{ count: number }>(this.db, `
+      SELECT COUNT(*) as count FROM stories
       WHERE assigned_agent_id = ?
         AND status IN ('in_progress', 'review', 'qa', 'qa_failed')
     `, [agentId]);
-    return activeStories.length;
+    return result?.count || 0;
   }
 
   /**

--- a/src/utils/auto-merge.ts
+++ b/src/utils/auto-merge.ts
@@ -1,0 +1,100 @@
+import { join } from 'path';
+import type { DatabaseClient } from '../db/client.js';
+import { withTransaction } from '../db/client.js';
+import { getApprovedPullRequests, updatePullRequest } from '../db/queries/pull-requests.js';
+import { getAllTeams } from '../db/queries/teams.js';
+import { updateStory } from '../db/queries/stories.js';
+import { createLog } from '../db/queries/logs.js';
+
+/**
+ * Auto-merge all approved PRs that are ready to merge
+ * Can be called immediately after PR approval or from manager daemon
+ *
+ * @param root - Hive root directory
+ * @param db - Database client
+ * @returns Number of PRs successfully merged
+ */
+export async function autoMergeApprovedPRs(root: string, db: DatabaseClient): Promise<number> {
+  const approvedPRs = getApprovedPullRequests(db.db);
+  if (approvedPRs.length === 0) return 0;
+
+  let mergedCount = 0;
+
+  for (const pr of approvedPRs) {
+    // Skip PRs without GitHub PR numbers
+    if (!pr.github_pr_number) continue;
+
+    try {
+      // Get team to find repo path
+      let teamId = pr.team_id;
+      let repoCwd = root;
+
+      if (teamId) {
+        const team = getAllTeams(db.db).find(t => t.id === teamId);
+        if (team?.repo_path) {
+          repoCwd = join(root, team.repo_path);
+        }
+      } else if (pr.branch_name) {
+        // Try to find team by matching branch name pattern
+        const teams = getAllTeams(db.db);
+        for (const team of teams) {
+          if (team.repo_path) {
+            repoCwd = join(root, team.repo_path);
+            teamId = team.id;
+            break;
+          }
+        }
+      }
+
+      // Attempt to merge on GitHub
+      const { execSync } = await import('child_process');
+      try {
+        execSync(`gh pr merge ${pr.github_pr_number} --auto --squash --delete-branch`, { stdio: 'pipe', cwd: repoCwd });
+
+        // Update PR and story status, create logs (atomic transaction)
+        const storyId = pr.story_id;
+        await withTransaction(db.db, () => {
+          updatePullRequest(db.db, pr.id, { status: 'merged' });
+
+          if (storyId) {
+            updateStory(db.db, storyId, { status: 'merged' });
+            createLog(db.db, {
+              agentId: 'manager',
+              storyId: storyId,
+              eventType: 'STORY_MERGED',
+              message: `Story auto-merged from GitHub PR #${pr.github_pr_number}`,
+            });
+          } else {
+            createLog(db.db, {
+              agentId: 'manager',
+              eventType: 'PR_MERGED',
+              message: `PR ${pr.id} auto-merged (GitHub PR #${pr.github_pr_number})`,
+              metadata: { pr_id: pr.id },
+            });
+          }
+        });
+
+        mergedCount++;
+      } catch (mergeErr) {
+        // Log merge failure but continue with other PRs
+        createLog(db.db, {
+          agentId: 'manager',
+          storyId: pr.story_id || undefined,
+          eventType: 'PR_MERGE_FAILED',
+          status: 'error',
+          message: `Failed to auto-merge PR ${pr.id} (GitHub PR #${pr.github_pr_number}): ${mergeErr instanceof Error ? mergeErr.message : 'Unknown error'}`,
+          metadata: { pr_id: pr.id },
+        });
+      }
+    } catch {
+      // Non-fatal - continue with other PRs
+      continue;
+    }
+  }
+
+  if (mergedCount > 0) {
+    db.save();
+  }
+
+  return mergedCount;
+}


### PR DESCRIPTION
## Summary
- **Extract `autoMergeApprovedPRs`** from `manager.ts` into a shared utility at `src/utils/auto-merge.ts` so it can be reused
- **Trigger auto-merge immediately** in `hive pr approve` (`pr.ts`) instead of waiting for the next manager daemon cycle (addresses INFRA-005 pain point)
- **Optimize `getAgentWorkload`** in `scheduler.ts` to use `SELECT COUNT(*)` instead of fetching all rows

## Changed files
- `src/utils/auto-merge.ts` — new shared auto-merge utility
- `src/cli/commands/manager.ts` — import shared utility, remove inline implementation
- `src/cli/commands/pr.ts` — call `autoMergeApprovedPRs` immediately after approval
- `src/orchestrator/scheduler.ts` — use `COUNT(*)` query for workload calculation

## Test plan
- [ ] Run `hive pr approve <id>` on an approved PR and verify it attempts immediate merge
- [ ] Verify manager daemon still auto-merges PRs on its regular cycle
- [ ] Verify `getAgentWorkload` returns correct count with active stories

STORY-IMP-016

🤖 Generated with [Claude Code](https://claude.com/claude-code)