### PR TITLE
feat: add hive version command

### DIFF
--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -15,3 +15,4 @@ export { myStoriesCommand } from './my-stories.js';
 export { prCommand } from './pr.js';
 export { managerCommand } from './manager.js';
 export { cleanupCommand } from './cleanup.js';
+export { versionCommand } from './version.js';

--- a/src/cli/commands/version.ts
+++ b/src/cli/commands/version.ts
@@ -1,0 +1,17 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { getVersion } from '../../utils/version.js';
+
+export const versionCommand = new Command('version')
+  .description('Show Hive version and system information')
+  .action(() => {
+    const version = getVersion();
+    const nodeVersion = process.version;
+    const platform = process.platform;
+
+    console.log();
+    console.log(chalk.cyan(`Hive v${version}`));
+    console.log(chalk.gray(`Node.js: ${nodeVersion}`));
+    console.log(chalk.gray(`Platform: ${platform}`));
+    console.log();
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,16 +21,19 @@ import {
   prCommand,
   managerCommand,
   cleanupCommand,
+  versionCommand,
 } from './cli/commands/index.js';
+import { getVersion } from './utils/version.js';
 
 const program = new Command();
 
 program
   .name('hive')
   .description('AI Agent Orchestrator - Manage agile software development teams of AI agents')
-  .version('0.1.0');
+  .version(getVersion());
 
 // Core commands
+program.addCommand(versionCommand);
 program.addCommand(initCommand);
 program.addCommand(configCommand);
 

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+let cachedVersion: string | null = null;
+
+export function getVersion(): string {
+  // Return cached version if available
+  if (cachedVersion) {
+    return cachedVersion;
+  }
+
+  try {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+
+    // Try to read package.json from multiple possible locations
+    const possiblePaths = [
+      join(__dirname, '../../package.json'), // For compiled dist/utils/version.js
+      join(__dirname, '../../../package.json'), // Fallback for nested builds
+      join(process.cwd(), 'package.json'), // Current working directory fallback
+    ];
+
+    for (const packageJsonPath of possiblePaths) {
+      try {
+        const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+        if (packageJson.version) {
+          cachedVersion = packageJson.version as string;
+          return cachedVersion!;
+        }
+      } catch {
+        // Try next path
+        continue;
+      }
+    }
+
+    // Fallback version
+    cachedVersion = '0.0.0';
+    return cachedVersion;
+  } catch {
+    cachedVersion = '0.0.0';
+    return cachedVersion;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `hive version` command that displays installed version, Node.js version, and platform
- Reads version dynamically from package.json with multiple fallback paths
- Uses `.version()` on the root Commander program for `--version` flag support

**Story:** IMP-012

## Test plan
- [ ] Run `hive version` and verify output shows correct version
- [ ] Run `hive --version` and verify it shows version number
- [ ] Verify build passes with `npm run build`