### PR TITLE
Story STORY-REF-011: Fix escalation system - persist dedup state and add auto-resolution

### DIFF
--- a/src/db/queries/escalations.ts
+++ b/src/db/queries/escalations.ts
@@ -93,6 +93,24 @@ export function getPendingHumanEscalations(db: Database): EscalationRow[] {
   `);
 }
 
+export function getRecentEscalationsForAgent(db: Database, agentId: string, minutesBack: number = 30): EscalationRow[] {
+  return queryAll<EscalationRow>(db, `
+    SELECT * FROM escalations
+    WHERE from_agent_id = ?
+    AND created_at > datetime('now', ?)
+    ORDER BY created_at DESC
+  `, [agentId, `-${minutesBack} minutes`]);
+}
+
+export function getActiveEscalationsForAgent(db: Database, agentId: string): EscalationRow[] {
+  return queryAll<EscalationRow>(db, `
+    SELECT * FROM escalations
+    WHERE from_agent_id = ?
+    AND status IN ('pending', 'acknowledged')
+    ORDER BY created_at DESC
+  `, [agentId]);
+}
+
 export function getAllEscalations(db: Database): EscalationRow[] {
   return queryAll<EscalationRow>(db, 'SELECT * FROM escalations ORDER BY created_at DESC');
 }


### PR DESCRIPTION
## Summary
Fixes STORY-REF-011: escalation system lost on manager restart causing duplicate escalations

## Problem
- Escalation dedup state (`escalatedSessions` set) was in-memory only, lost on manager restart
- When escalation status changes from 'pending' to 'acknowledged'/'resolved', but agent still waiting, duplicate escalations were created
- No auto-resolution when agents recovered from the state that caused the escalation

## Solution
1. **Improved dedup logic**: Check for recent escalations (last 30 minutes) in addition to pending ones
   - Added `getRecentEscalationsForAgent()` function to query escalations within time window
   - Prevents duplicates even after manager restart since data is now DB-backed

2. **Auto-resolution**: Automatically resolve escalations when agents recover
   - Added `getActiveEscalationsForAgent()` function to get pending/acknowledged escalations
   - When agent moves out of waiting state, auto-resolve their active escalations
   - Shows clear resolution message: "Agent recovered: no longer in waiting state"

3. **Comprehensive tests**: Added 6 new tests for escalation query functions
   - Tests for recent escalations filtering
   - Tests for active escalations (pending/acknowledged only)
   - Edge cases and empty results

## Changes
- `src/db/queries/escalations.ts`: Added two new query functions
- `src/cli/commands/manager.ts`: Improved escalation handling with dedup and auto-resolution
- `src/db/queries/escalations.test.ts`: Added 6 new test cases

## Test Plan
- ✅ All 376 existing tests pass
- ✅ 6 new escalation tests added and passing
- ✅ Build succeeds with TypeScript type checking

🤖 Generated with [Claude Code](https://claude.com/claude-code)