### PR TITLE
fix(auto-merge): add optimistic locking to prevent race conditions [STORY-REF-007]

### DIFF
--- a/src/utils/auto-merge.ts
+++ b/src/utils/auto-merge.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import type { DatabaseClient } from '../db/client.js';
-import { withTransaction } from '../db/client.js';
+import { withTransaction, queryOne } from '../db/client.js';
 import { getApprovedPullRequests, updatePullRequest } from '../db/queries/pull-requests.js';
 import { getAllTeams } from '../db/queries/teams.js';
 import { updateStory } from '../db/queries/stories.js';
@@ -25,6 +25,29 @@ export async function autoMergeApprovedPRs(root: string, db: DatabaseClient): Pr
     if (!pr.github_pr_number) continue;
 
     try {
+      // Atomically claim this PR for merging using optimistic locking
+      // This prevents race conditions when multiple managers run concurrently
+      let claimed = false;
+      await withTransaction(db.db, () => {
+        // Re-fetch PR status to ensure it's still 'approved'
+        const currentPR = queryOne<{ status: string }>(
+          db.db,
+          `SELECT status FROM pull_requests WHERE id = ?`,
+          [pr.id]
+        );
+
+        if (currentPR?.status === 'approved') {
+          // Update to 'queued' status (temporary merge-in-progress state)
+          // Only this manager will proceed if status was 'approved'
+          updatePullRequest(db.db, pr.id, { status: 'queued' });
+          claimed = true;
+        }
+      });
+      db.save();
+
+      // If we didn't claim the PR, another manager is already merging it
+      if (!claimed) continue;
+
       // Get team to find repo path
       let teamId = pr.team_id;
       let repoCwd = root;
@@ -49,6 +72,8 @@ export async function autoMergeApprovedPRs(root: string, db: DatabaseClient): Pr
       // Attempt to merge on GitHub
       const { execSync } = await import('child_process');
       try {
+        // Use --auto flag to enable GitHub's auto-merge feature
+        // This makes the operation more idempotent - if already merged, gh will handle it gracefully
         execSync(`gh pr merge ${pr.github_pr_number} --auto --squash --delete-branch`, { stdio: 'pipe', cwd: repoCwd });
 
         // Update PR and story status, create logs (atomic transaction)
@@ -75,25 +100,26 @@ export async function autoMergeApprovedPRs(root: string, db: DatabaseClient): Pr
         });
 
         mergedCount++;
+        db.save();
       } catch (mergeErr) {
-        // Log merge failure but continue with other PRs
-        createLog(db.db, {
-          agentId: 'manager',
-          storyId: pr.story_id || undefined,
-          eventType: 'PR_MERGE_FAILED',
-          status: 'error',
-          message: `Failed to auto-merge PR ${pr.id} (GitHub PR #${pr.github_pr_number}): ${mergeErr instanceof Error ? mergeErr.message : 'Unknown error'}`,
-          metadata: { pr_id: pr.id },
+        // Merge failed - revert PR status back to approved for retry
+        await withTransaction(db.db, () => {
+          updatePullRequest(db.db, pr.id, { status: 'approved' });
+          createLog(db.db, {
+            agentId: 'manager',
+            storyId: pr.story_id || undefined,
+            eventType: 'PR_MERGE_FAILED',
+            status: 'error',
+            message: `Failed to auto-merge PR ${pr.id} (GitHub PR #${pr.github_pr_number}): ${mergeErr instanceof Error ? mergeErr.message : 'Unknown error'}`,
+            metadata: { pr_id: pr.id },
+          });
         });
+        db.save();
       }
     } catch {
       // Non-fatal - continue with other PRs
       continue;
     }
-  }
-
-  if (mergedCount > 0) {
-    db.save();
   }
 
   return mergedCount;


### PR DESCRIPTION
Fix race condition where multiple managers could merge same PR. Added optimistic locking to atomically claim PRs before merge. STORY-REF-007