### PR TITLE
Story STORY-REF-026: Graceful QA agent scale-down - never kill agent mid-review

### DIFF
--- a/src/db/queries/pull-requests.ts
+++ b/src/db/queries/pull-requests.ts
@@ -227,6 +227,18 @@ export function deletePullRequest(db: Database, id: string): void {
 }
 
 /**
+ * Check if an agent is actively reviewing a PR
+ * Returns true if the agent has a PR with status 'reviewing'
+ */
+export function isAgentReviewingPR(db: Database, agentId: string): boolean {
+  const result = queryOne<{ count: number }>(db, `
+    SELECT COUNT(*) as count FROM pull_requests
+    WHERE reviewed_by = ? AND status = 'reviewing'
+  `, [agentId]);
+  return (result?.count || 0) > 0;
+}
+
+/**
  * Backfill github_pr_number for existing PRs that have github_pr_url but no number
  * This is an idempotent operation - it only updates PRs with NULL github_pr_number
  * @returns Number of PRs updated


### PR DESCRIPTION
## Summary
Implement graceful scale-down for QA agents to prevent terminating agents that are actively reviewing PRs.

## Changes
- Add `isAgentReviewingPR()` helper function to the pull-requests query module
- Update `scaleQAAgents()` to filter out agents currently reviewing before selecting agents to terminate
- Add comprehensive tests for the new functionality

## Details
When the system decides to scale down QA agents due to a shrinking merge queue, it now:
1. Checks if each candidate agent has a PR in 'reviewing' status
2. Skips terminating agents that are actively reviewing
3. Only terminates agents with no active reviews

## Test Results
- All 376 existing tests pass
- Added 6 new tests for `isAgentReviewingPR()` function
- All new tests pass

## Acceptance Criteria
- ✅ QA agents are never terminated while actively reviewing
- ✅ Scale-down only terminates agents with no active reviews
- ✅ All existing tests pass
- ✅ New tests verify the behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)