### PR TITLE
feat(readme): Add project badges to header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Hive - AI Agent Orchestrator
 
+[![CI](https://github.com/nikrich/hungry-ghost-hive/actions/workflows/ci.yml/badge.svg)](https://github.com/nikrich/hungry-ghost-hive/actions/workflows/ci.yml)
+[![npm version](https://badge.fury.io/js/hungry-ghost-hive.svg)](https://www.npmjs.com/package/hungry-ghost-hive)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D18-brightgreen)](https://nodejs.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.0-blue.svg)](https://www.typescriptlang.org/)
+
 <img width="1263" height="651" alt="image" src="https://github.com/user-attachments/assets/76eb8bd9-d5ec-45b7-9ee2-b7ef910f3e88" />
 
 Hive is a CLI tool that orchestrates AI agents modeled after agile software development teams. You act as the **Product Owner**, providing requirements. Hive's AI agents handle the rest—from planning through to PR submission.


### PR DESCRIPTION
## Summary
- Add shields.io badges to README header between title and screenshot
- Includes CI/Build status, npm version, Node.js requirement (>=18), MIT License, and TypeScript badges
- All badges include proper links for easy navigation

## Acceptance Criteria
- [x] CI/Build status badge shows current GitHub Actions workflow status
- [x] npm version badge links to npm package page
- [x] Node.js version badge shows >=18 requirement
- [x] License badge present
- [x] TypeScript badge present
- [x] Badges are placed between the title and the screenshot image
- [x] All badge links resolve correctly
- [x] README renders properly on GitHub

## Test Plan
- [x] Verify badges display correctly on GitHub
- [x] Click each badge link to verify they resolve
- [x] Confirm README renders without markdown errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)