### PR TITLE
STORY-ENT-001: Add project badges to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Hive - AI Agent Orchestrator
 
+[![CI](https://img.shields.io/github/actions/workflow/status/nikrich/hungry-ghost-hive/ci.yml?branch=main&style=flat-square)](https://github.com/nikrich/hungry-ghost-hive/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/hungry-ghost-hive?style=flat-square)](https://www.npmjs.com/package/hungry-ghost-hive)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D18-brightgreen?style=flat-square)](https://nodejs.org/)
+[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
+[![TypeScript](https://img.shields.io/badge/language-TypeScript-blue?style=flat-square)](https://www.typescriptlang.org/)
+
 <img width="1263" height="651" alt="image" src="https://github.com/user-attachments/assets/76eb8bd9-d5ec-45b7-9ee2-b7ef910f3e88" />
 
 Hive is a CLI tool that orchestrates AI agents modeled after agile software development teams. You act as the **Product Owner**, providing requirements. Hive's AI agents handle the rest—from planning through to PR submission.


### PR DESCRIPTION
## Summary

Adds shields.io badges to the README.md header for better project visibility. Badges include CI/CD status, npm package version, Node.js version requirement, license, and TypeScript language indicator.

## Badges Added

- CI/Build Status: GitHub Actions workflow status
- npm Version: Link to npm package page
- Node.js Version: Shows >=18 requirement
- License: MIT license badge
- TypeScript: Language badge

## Acceptance Criteria

- [x] CI/Build status badge shows current GitHub Actions workflow status
- [x] npm version badge links to npm package page
- [x] Node.js version badge shows >=18 requirement
- [x] License badge present
- [x] TypeScript badge present
- [x] Badges are placed between the title and the screenshot image
- [x] All badge links resolve correctly
- [x] README renders properly on GitHub

Closes STORY-ENT-001