### PR TITLE
fix: Correct license references from MIT to Proprietary

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/nikrich/hungry-ghost-hive/ci.yml?branch=main&style=flat-square)](https://github.com/nikrich/hungry-ghost-hive/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/hungry-ghost-hive?style=flat-square)](https://www.npmjs.com/package/hungry-ghost-hive)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D18-brightgreen?style=flat-square)](https://nodejs.org/)
-[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
+[![License](https://img.shields.io/badge/license-Proprietary-blue?style=flat-square)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/language-TypeScript-blue?style=flat-square)](https://www.typescriptlang.org/)
 [![Codecov](https://img.shields.io/codecov/c/github/nikrich/hungry-ghost-hive?style=flat-square)](https://codecov.io/gh/nikrich/hungry-ghost-hive)
 
@@ -448,4 +448,4 @@ git status  # MUST show "up to date with origin"
 
 ## License
 
-MIT
+See [LICENSE](LICENSE) file for details. This project uses a proprietary Hungry Ghost Hive License.


### PR DESCRIPTION
## Summary
Corrects incorrect MIT license references in README.md to accurately reflect the proprietary Hungry Ghost Hive License.

## Changes
- **License badge**: Changed from MIT to Proprietary
- **License section footer**: Updated from "MIT" to proper description with LICENSE file reference

## Context
The project uses a custom proprietary license (see LICENSE file), but the README incorrectly referenced MIT in two places. This PR fixes those references to match the actual license.

## Files Changed
- `README.md`: 2 lines updated (badge + footer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)