### PR TITLE
Story STORY-FIX-001: Fix QA agent premature termination when stories are in qa_failed status

### DIFF
--- a/src/orchestrator/scheduler.ts
+++ b/src/orchestrator/scheduler.ts
@@ -518,10 +518,10 @@ export class Scheduler {
    * - Scale down excess QA agents when queue shrinks
    */
   private async scaleQAAgents(teamId: string, teamName: string, repoPath: string): Promise<void> {
-    // Count pending QA work: stories in 'qa' or 'pr_submitted' status
+    // Count pending QA work: stories in 'qa', 'pr_submitted', or 'qa_failed' status
     const qaStories = queryAll<StoryRow>(this.db, `
       SELECT * FROM stories
-      WHERE team_id = ? AND status IN ('qa', 'pr_submitted')
+      WHERE team_id = ? AND status IN ('qa', 'pr_submitted', 'qa_failed')
     `, [teamId]);
 
     const pendingCount = qaStories.length;


### PR DESCRIPTION
## Summary
Fixed a bug in the QA agent scaling logic where agents would terminate prematurely when stories were in `qa_failed` status.

## Problem
The `scaleQAAgents()` function in `scheduler.ts` only counted stories with status `IN ('qa', 'pr_submitted')` when calculating pending QA work. This caused QA agents to incorrectly scale down and terminate even when there were stories in `qa_failed` status that still needed QA review.

## Solution
Updated the query to include `qa_failed` status:
```
WHERE team_id = ? AND status IN ('qa', 'pr_submitted', 'qa_failed')
```

Stories in `qa_failed` state are still pending QA work that requires re-review, so they should be counted in the pending work to prevent early agent termination.

## Changes
- Modified `src/orchestrator/scheduler.ts` line 524 to include `'qa_failed'` in the status filter

## Testing
- All existing tests pass (431 tests)
- Build succeeds with no TypeScript errors
- Lint check passes

🤖 Generated with Claude Code