### PR TITLE
fix: use actual repo contributors from GitHub

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -8,20 +8,21 @@
   "contributors": [
     {
       "login": "nikrich",
-      "name": "Jannik Richter",
-      "avatar_url": "https://avatars.githubusercontent.com/u/12345678?v=4",
+      "name": "nikrich",
+      "avatar_url": "https://avatars.githubusercontent.com/u/8254123?v=4",
       "profile": "https://github.com/nikrich",
       "contributions": [
         "code",
         "doc",
-        "infra"
+        "infra",
+        "maintenance"
       ]
     },
     {
-      "login": "mayor-bot",
-      "name": "Mayor",
-      "avatar_url": "https://avatars.githubusercontent.com/u/87654321?v=4",
-      "profile": "https://github.com/mayor-bot",
+      "login": "aleeuwen73",
+      "name": "Alastair van Leeuwen",
+      "avatar_url": "https://avatars.githubusercontent.com/u/73424841?v=4",
+      "profile": "https://github.com/aleeuwen73",
       "contributions": [
         "code"
       ]

--- a/README.md
+++ b/README.md
@@ -365,8 +365,8 @@ We appreciate contributions from everyone! This project is built and maintained 
 <!-- markdownlint-disable -->
 <table>
   <tr>
-    <td align="center"><a href="https://github.com/nikrich"><img src="https://avatars.githubusercontent.com/u/12345678?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Jannik Richter</b></sub></a><br /><a href="https://github.com/nikrich/hungry-ghost-hive/commits?author=nikrich" title="Code">💻</a> <a href="https://github.com/nikrich/hungry-ghost-hive/commits?author=nikrich" title="Documentation">📖</a> <a href="#infra-nikrich" title="Infrastructure">🚀</a></td>
-    <td align="center"><a href="https://github.com/mayor-bot"><img src="https://avatars.githubusercontent.com/u/87654321?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Mayor</b></sub></a><br /><a href="https://github.com/nikrich/hungry-ghost-hive/commits?author=mayor-bot" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/nikrich"><img src="https://avatars.githubusercontent.com/u/8254123?v=4?s=100" width="100px;" alt=""/><br /><sub><b>nikrich</b></sub></a><br /><a href="https://github.com/nikrich/hungry-ghost-hive/commits?author=nikrich" title="Code">💻</a> <a href="https://github.com/nikrich/hungry-ghost-hive/commits?author=nikrich" title="Documentation">📖</a> <a href="#infra-nikrich" title="Infrastructure">🚀</a> <a href="#maintenance-nikrich" title="Maintenance">🚧</a></td>
+    <td align="center"><a href="https://github.com/aleeuwen73"><img src="https://avatars.githubusercontent.com/u/73424841?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alastair van Leeuwen</b></sub></a><br /><a href="https://github.com/nikrich/hungry-ghost-hive/commits?author=aleeuwen73" title="Code">💻</a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
## Summary
- Replaced fabricated contributor data with real contributors from `gh api repos/nikrich/hungry-ghost-hive/contributors`
- **nikrich** (u/8254123) - primary author, code/docs/infra/maintenance
- **aleeuwen73** (u/73424841) - Alastair van Leeuwen, code contributor
- Removed non-existent "mayor-bot" entry
- Fixed incorrect avatar URLs (was using made-up u/12345678)

## Files changed
- `.all-contributorsrc` - corrected contributor entries
- `README.md` - corrected contributor table HTML