### PR TITLE
fix: replace 'any' type with proper interface in auto-merge utility

### DIFF
--- a/src/utils/auto-merge.ts
+++ b/src/utils/auto-merge.ts
@@ -73,7 +73,7 @@ export async function autoMergeApprovedPRs(root: string, db: DatabaseClient): Pr
       const { execSync } = await import('child_process');
       try {
         // Verify PR state and mergeable status
-        let prState: any;
+        let prState: { state: string; mergeable: string };
         let mergeableStatus: boolean;
         try {
           const prViewOutput = execSync(`gh pr view ${pr.github_pr_number} --json state,mergeable`, {


### PR DESCRIPTION
## Summary
This PR fixes a TypeScript linting warning by replacing the implicit 'any' type annotation with an explicit object type.

## Changes
- Updated `prState` type annotation from `any` to `{ state: string; mergeable: string }` in the auto-merge utility
- This improves type safety and satisfies ESLint strict type checking rules

## Testing
- All 431 tests pass
- Linting now passes with 0 errors
- TypeScript type checking passes
- Build completes successfully

🤖 Generated with Claude Code