### PR TITLE
style: format remaining files

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,7 +1,5 @@
 {
-  "files": [
-    "README.md"
-  ],
+  "files": ["README.md"],
   "imageSize": 100,
   "commit": false,
   "commitConvention": "angular",
@@ -11,21 +9,14 @@
       "name": "nikrich",
       "avatar_url": "https://avatars.githubusercontent.com/u/8254123?v=4",
       "profile": "https://github.com/nikrich",
-      "contributions": [
-        "code",
-        "doc",
-        "infra",
-        "maintenance"
-      ]
+      "contributions": ["code", "doc", "infra", "maintenance"]
     },
     {
       "login": "aleeuwen73",
       "name": "Alastair van Leeuwen",
       "avatar_url": "https://avatars.githubusercontent.com/u/73424841?v=4",
       "profile": "https://github.com/aleeuwen73",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     }
   ],
   "contributorsPerLine": 7,

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: Report a bug to help us improve
-title: "[BUG] "
+title: '[BUG] '
 labels: bug
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 about: Suggest an idea to improve Hive
-title: "[FEATURE] "
+title: '[FEATURE] '
 labels: enhancement
 assignees: ''
 ---

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@
 ## Story ID
 
 <!-- Link to the related story/issue. Example: STORY-001, STORY-DOC-004, etc. -->
+
 Closes #
 
 ## Changes Checklist


### PR DESCRIPTION
Formats .all-contributorsrc and GitHub templates missed by PR #187 (which only ran on src/**/*.ts, while CI checks all files).