### PR TITLE
Story STORY-FIX-004: Fix GitHub merge sync - extractStoryIdFromBranch regex broken

### DIFF
--- a/src/utils/story-id.test.ts
+++ b/src/utils/story-id.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractStoryIdFromBranch,
+  isValidStoryId,
+  normalizeStoryId,
+  STORY_ID_PATTERN,
+} from './story-id.js';
+
+describe('Story ID utilities', () => {
+  describe('STORY_ID_PATTERN', () => {
+    it('should match valid story IDs', () => {
+      expect('STORY-001'.match(STORY_ID_PATTERN)).not.toBeNull();
+      expect('STORY-FIX-004'.match(STORY_ID_PATTERN)).not.toBeNull();
+      expect('STORY-REF-022'.match(STORY_ID_PATTERN)).not.toBeNull();
+      expect('STORY-ABC123XYZ'.match(STORY_ID_PATTERN)).not.toBeNull();
+    });
+  });
+
+  describe('isValidStoryId', () => {
+    it('should validate story IDs correctly', () => {
+      expect(isValidStoryId('STORY-001')).toBe(true);
+      expect(isValidStoryId('STORY-FIX-004')).toBe(true);
+      expect(isValidStoryId('STORY-REF-022')).toBe(true);
+    });
+
+    it('should reject invalid story IDs', () => {
+      expect(isValidStoryId('INVALID-001')).toBe(false);
+      expect(isValidStoryId('')).toBe(false);
+      expect(isValidStoryId(null)).toBe(false);
+      expect(isValidStoryId(undefined)).toBe(false);
+    });
+  });
+
+  describe('extractStoryIdFromBranch', () => {
+    it('should extract story ID from feature branch with prefix', () => {
+      expect(extractStoryIdFromBranch('feature/STORY-001-test')).toBe('STORY-001');
+      expect(extractStoryIdFromBranch('feature/STORY-FIX-004-description')).toBe(
+        'STORY-FIX-004'
+      );
+    });
+
+    it('should extract story ID from branch names with different prefixes', () => {
+      expect(extractStoryIdFromBranch('bugfix/STORY-REF-022-fix')).toBe('STORY-REF-022');
+      expect(extractStoryIdFromBranch('hotfix/STORY-IMP-003-critical')).toBe('STORY-IMP-003');
+    });
+
+    it('should extract story ID from branch names without prefix', () => {
+      expect(extractStoryIdFromBranch('STORY-001')).toBe('STORY-001');
+      expect(extractStoryIdFromBranch('STORY-FIX-004')).toBe('STORY-FIX-004');
+    });
+
+    it('should extract story ID with dashes in description', () => {
+      expect(extractStoryIdFromBranch('feature/STORY-123_fix-bug-with-dashes')).toBe(
+        'STORY-123'
+      );
+    });
+
+    it('should handle empty branch name', () => {
+      expect(extractStoryIdFromBranch('')).toBeNull();
+    });
+
+    it('should return null for branch without story ID', () => {
+      expect(extractStoryIdFromBranch('feature/some-other-branch')).toBeNull();
+      expect(extractStoryIdFromBranch('main')).toBeNull();
+      expect(extractStoryIdFromBranch('develop')).toBeNull();
+    });
+
+    it('should be case-insensitive', () => {
+      expect(extractStoryIdFromBranch('feature/story-001-test')).toBe('STORY-001');
+      expect(extractStoryIdFromBranch('feature/Story-FIX-004-description')).toBe('STORY-FIX-004');
+    });
+  });
+
+  describe('normalizeStoryId', () => {
+    it('should normalize story IDs to uppercase', () => {
+      expect(normalizeStoryId('story-001')).toBe('STORY-001');
+      expect(normalizeStoryId('Story-FIX-004')).toBe('STORY-FIX-004');
+      expect(normalizeStoryId('STORY-REF-022')).toBe('STORY-REF-022');
+    });
+  });
+});

--- a/src/utils/story-id.ts
+++ b/src/utils/story-id.ts
@@ -5,28 +5,70 @@
  */
 
 /**
- * Regex pattern for validating story IDs
+ * Regex pattern for extracting story IDs from branch names
  * Matches: STORY-<alphanumeric and hyphens>
  * Examples: STORY-IMP-003, STORY-REF-022, STORY-ABC123XYZ
  */
-export const STORY_ID_PATTERN = /^STORY-[A-Z0-9]+(-[A-Z0-9]+)*$/i;
+export const STORY_ID_PATTERN = /STORY-[A-Z0-9]+(-[A-Z0-9]+)*/i;
 
 /**
  * Validate if a string is a valid story ID
  */
 export function isValidStoryId(id: string | undefined | null): id is string {
   if (!id || typeof id !== 'string') return false;
-  return STORY_ID_PATTERN.test(id);
+  return /^STORY-[A-Z0-9]+(-[A-Z0-9]+)*$/i.test(id);
 }
 
 /**
  * Extract story ID from a branch name
  * Supports patterns like: feature/STORY-001-description, STORY-REF-022, etc.
+ * The function extracts the story ID and removes any trailing segments that look like descriptions
+ * (segments containing lowercase letters that aren't pure digits or uppercase)
  */
 export function extractStoryIdFromBranch(branchName: string): string | null {
   if (!branchName) return null;
   const match = branchName.match(STORY_ID_PATTERN);
-  return match ? match[0].toUpperCase() : null;
+  if (!match) return null;
+
+  // Get the original matched text (preserving case)
+  const matchedText = match[0];
+  const matchStart = branchName.indexOf(matchedText);
+
+  // Split the matched text into segments
+  const segments = matchedText.split('-');
+
+  // Find where the story ID actually ends
+  // It ends before a segment that looks like a description (contains lowercase and isn't purely numeric)
+  let endSegmentIdx = segments.length;
+  let currentPos = matchStart;
+
+  for (let i = 0; i < segments.length; i++) {
+    if (i > 0) {
+      currentPos += 1; // account for the dash
+    }
+    const segment = branchName.substring(currentPos, currentPos + segments[i].length);
+    currentPos += segments[i].length;
+
+    // Story ID segments are typically:
+    // - First segment: "STORY" (or "story", "Story" due to case-insensitive match)
+    // - Following segments: uppercase letters, digits, or pure digits
+    // Description segments contain lowercase letters mixed with other characters (not pure digits)
+    const isDescriptionLike =
+      i > 0 && // Not the first segment
+      /[a-z]/.test(segment) && // Contains lowercase
+      !/^\d+$/.test(segment); // Not pure digits
+
+    if (isDescriptionLike) {
+      endSegmentIdx = i;
+      break;
+    }
+  }
+
+  // Reconstruct the story ID from the valid segments
+  const storyIdParts = segments.slice(0, endSegmentIdx);
+  const storyId = storyIdParts.join('-').toUpperCase();
+
+  return storyId;
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixed critical bug in `extractStoryIdFromBranch` function that prevented story IDs from being extracted from branch names with prefixes (e.g., `feature/STORY-001-description`).

The regex pattern was using start/end anchors (`^` and `$`) which only matched strings that started with "STORY-", failing to extract from typical branch names like `feature/STORY-001-test`.

## Changes
- Modified `STORY_ID_PATTERN` regex to allow matching story IDs anywhere in a string
- Updated `extractStoryIdFromBranch` function to post-process matches and remove description segments
- Created comprehensive test suite with 11 test cases covering various scenarios
- All 898 existing tests continue to pass

## Test Plan
- [x] All existing 898 tests pass
- [x] New test suite (11 tests) for story-id utilities passes
- [x] Linting and type checking pass
- [x] Tested with branch names:
  - `feature/STORY-001-test` → extracts `STORY-001`
  - `feature/STORY-FIX-004-description` → extracts `STORY-FIX-004`
  - `bugfix/story-001-fix` → extracts `STORY-001` (case-insensitive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)