### PR TITLE
refactor: extract duplicated worktree removal and PR sync into shared utils

### DIFF
--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -9,6 +9,7 @@ import {
   getAllAgents,
 } from '../../db/queries/agents.js';
 import { getLogsByAgent } from '../../db/queries/logs.js';
+import { removeWorktree } from '../../git/worktree.js';
 import { statusColor } from '../../utils/logger.js';
 import { findHiveRoot, getHivePaths } from '../../utils/paths.js';
 
@@ -229,18 +230,10 @@ agentsCommand
         try {
           // Remove worktree if exists
           if (agent.worktree_path) {
-            try {
-              const { execSync } = await import('child_process');
-              const fullWorktreePath = `${root}/${agent.worktree_path}`;
-              execSync(`git worktree remove "${fullWorktreePath}" --force`, {
-                cwd: root,
-                stdio: 'pipe',
-              });
-            } catch (err) {
+            const result = removeWorktree(root, agent.worktree_path);
+            if (!result.success) {
               console.error(
-                chalk.yellow(
-                  `Warning: Failed to remove worktree for ${agent.id}: ${err instanceof Error ? err.message : 'Unknown error'}`
-                )
+                chalk.yellow(`Warning: Failed to remove worktree for ${agent.id}: ${result.error}`)
               );
             }
           }

--- a/src/cli/commands/manager.ts
+++ b/src/cli/commands/manager.ts
@@ -23,13 +23,15 @@ import {
 } from '../../db/queries/messages.js';
 import {
   backfillGithubPrNumbers,
-  createPullRequest,
   getMergeQueue,
   getPullRequestsByStatus,
-  type PullRequestRow,
   updatePullRequest,
 } from '../../db/queries/pull-requests.js';
-import { getStoriesByStatus, updateStory, updateStoryAssignment } from '../../db/queries/stories.js';
+import {
+  getStoriesByStatus,
+  updateStory,
+  updateStoryAssignment,
+} from '../../db/queries/stories.js';
 import { getAllTeams } from '../../db/queries/teams.js';
 import { Scheduler } from '../../orchestrator/scheduler.js';
 import {
@@ -56,6 +58,7 @@ import {
   type CLITool,
 } from '../../utils/cli-commands.js';
 import { findHiveRoot, getHivePaths } from '../../utils/paths.js';
+import { getExistingPRIdentifiers, syncOpenGitHubPRs } from '../../utils/pr-sync.js';
 import { extractStoryIdFromBranch } from '../../utils/story-id.js';
 
 // --- Named constants (extracted from inline magic numbers) ---
@@ -1027,11 +1030,8 @@ async function syncGitHubPRs(root: string, db: DatabaseClient, _hiveDir: string)
   const teams = getAllTeams(db.db);
   if (teams.length === 0) return 0;
 
-  // Get ALL existing PRs (including merged/closed) to prevent duplicate imports
-  const existingPRs = queryAll<PullRequestRow>(db.db, 'SELECT * FROM pull_requests');
-  // Include ALL branch names to prevent duplicate entries for merged/closed PRs
-  const existingBranches = new Set(existingPRs.map(pr => pr.branch_name));
-  const existingPrNumbers = new Set(existingPRs.map(pr => pr.github_pr_number).filter(Boolean));
+  // Include ALL branch names (including merged/closed) to prevent duplicate entries
+  const { existingBranches, existingPrNumbers } = getExistingPRIdentifiers(db.db, true);
 
   let synced = 0;
 
@@ -1041,36 +1041,14 @@ async function syncGitHubPRs(root: string, db: DatabaseClient, _hiveDir: string)
     const repoDir = `${root}/${team.repo_path}`;
 
     try {
-      const result = await execa(
-        'gh',
-        ['pr', 'list', '--json', 'number,headRefName,url,title', '--state', 'open'],
-        {
-          cwd: repoDir,
-        }
+      const result = await syncOpenGitHubPRs(
+        db.db,
+        repoDir,
+        team.id,
+        existingBranches,
+        existingPrNumbers
       );
-      const ghPRs: Array<{ number: number; headRefName: string; url: string; title: string }> =
-        JSON.parse(result.stdout);
-
-      for (const ghPR of ghPRs) {
-        // Skip if already in queue
-        if (existingBranches.has(ghPR.headRefName) || existingPrNumbers.has(ghPR.number)) {
-          continue;
-        }
-
-        // Try to match to a story by parsing branch name using unified pattern
-        const storyId = extractStoryIdFromBranch(ghPR.headRefName);
-
-        createPullRequest(db.db, {
-          storyId,
-          teamId: team.id,
-          branchName: ghPR.headRefName,
-          githubPrNumber: ghPR.number,
-          githubPrUrl: ghPR.url,
-          submittedBy: null,
-        });
-
-        synced++;
-      }
+      synced += result.synced;
     } catch (_error) {
       // gh CLI might not be authenticated or repo might not have remote
       continue;

--- a/src/git/worktree.test.ts
+++ b/src/git/worktree.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { removeWorktree } from './worktree.js';
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+import { execSync } from 'child_process';
+
+const mockExecSync = vi.mocked(execSync);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('removeWorktree', () => {
+  it('should return success when worktree is removed', () => {
+    mockExecSync.mockReturnValue(Buffer.from(''));
+
+    const result = removeWorktree('/root', 'repos/team-agent-1');
+
+    expect(result.success).toBe(true);
+    expect(result.fullWorktreePath).toBe('/root/repos/team-agent-1');
+    expect(result.error).toBeUndefined();
+    expect(mockExecSync).toHaveBeenCalledWith(
+      'git worktree remove "/root/repos/team-agent-1" --force',
+      { cwd: '/root', stdio: 'pipe', timeout: 30000 }
+    );
+  });
+
+  it('should return success for empty worktree path without running git', () => {
+    const result = removeWorktree('/root', '');
+
+    expect(result.success).toBe(true);
+    expect(mockExecSync).not.toHaveBeenCalled();
+  });
+
+  it('should return failure with error message on git error', () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('Permission denied');
+    });
+
+    const result = removeWorktree('/root', 'repos/team-agent-1');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Permission denied');
+    expect(result.fullWorktreePath).toBe('/root/repos/team-agent-1');
+  });
+
+  it('should use custom timeout when provided', () => {
+    mockExecSync.mockReturnValue(Buffer.from(''));
+
+    removeWorktree('/root', 'repos/team-agent-1', { timeout: 60000 });
+
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ timeout: 60000 })
+    );
+  });
+
+  it('should use default 30s timeout when not specified', () => {
+    mockExecSync.mockReturnValue(Buffer.from(''));
+
+    removeWorktree('/root', 'repos/team-agent-1');
+
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ timeout: 30000 })
+    );
+  });
+
+  it('should handle non-Error thrown objects', () => {
+    mockExecSync.mockImplementation(() => {
+      throw 'string error';
+    });
+
+    const result = removeWorktree('/root', 'repos/team-agent-1');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Unknown error');
+  });
+});

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -1,0 +1,42 @@
+import { execSync } from 'child_process';
+
+export interface RemoveWorktreeResult {
+  success: boolean;
+  error?: string;
+  fullWorktreePath: string;
+}
+
+/**
+ * Remove a git worktree at the given path.
+ *
+ * @param rootDir   - The root directory of the hive workspace
+ * @param worktreePath - Relative worktree path (e.g. "repos/team-agent-1")
+ * @param options.timeout - Git command timeout in ms (default: 30000)
+ * @returns Result indicating success/failure with error details
+ */
+export function removeWorktree(
+  rootDir: string,
+  worktreePath: string,
+  options?: { timeout?: number }
+): RemoveWorktreeResult {
+  const fullWorktreePath = `${rootDir}/${worktreePath}`;
+
+  if (!worktreePath) {
+    return { success: true, fullWorktreePath };
+  }
+
+  try {
+    execSync(`git worktree remove "${fullWorktreePath}" --force`, {
+      cwd: rootDir,
+      stdio: 'pipe',
+      timeout: options?.timeout ?? 30000,
+    });
+    return { success: true, fullWorktreePath };
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : 'Unknown error',
+      fullWorktreePath,
+    };
+  }
+}

--- a/src/utils/pr-sync.test.ts
+++ b/src/utils/pr-sync.test.ts
@@ -1,0 +1,233 @@
+import type { Database } from 'sql.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPullRequest } from '../db/queries/pull-requests.js';
+import { createTestDatabase } from '../db/queries/test-helpers.js';
+import { getExistingPRIdentifiers, syncOpenGitHubPRs } from './pr-sync.js';
+
+vi.mock('execa', () => ({
+  execa: vi.fn(),
+}));
+
+import { execa } from 'execa';
+
+const mockExeca = vi.mocked(execa);
+
+let db: Database;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  db = await createTestDatabase();
+});
+
+describe('getExistingPRIdentifiers', () => {
+  it('should return empty sets when no PRs exist', () => {
+    const { existingBranches, existingPrNumbers } = getExistingPRIdentifiers(db);
+
+    expect(existingBranches.size).toBe(0);
+    expect(existingPrNumbers.size).toBe(0);
+  });
+
+  it('should include all branch names when includeTerminalBranches is true', () => {
+    createPullRequest(db, { branchName: 'feature/open', githubPrNumber: 1 });
+    const mergedPR = createPullRequest(db, {
+      branchName: 'feature/merged',
+      githubPrNumber: 2,
+    });
+    // Manually set status to merged
+    db.run("UPDATE pull_requests SET status = 'merged' WHERE id = ?", [mergedPR.id]);
+
+    const { existingBranches } = getExistingPRIdentifiers(db, true);
+
+    expect(existingBranches.has('feature/open')).toBe(true);
+    expect(existingBranches.has('feature/merged')).toBe(true);
+  });
+
+  it('should exclude terminal branch names when includeTerminalBranches is false', () => {
+    createPullRequest(db, { branchName: 'feature/open', githubPrNumber: 1 });
+    const mergedPR = createPullRequest(db, {
+      branchName: 'feature/merged',
+      githubPrNumber: 2,
+    });
+    const closedPR = createPullRequest(db, {
+      branchName: 'feature/closed',
+      githubPrNumber: 3,
+    });
+    db.run("UPDATE pull_requests SET status = 'merged' WHERE id = ?", [mergedPR.id]);
+    db.run("UPDATE pull_requests SET status = 'closed' WHERE id = ?", [closedPR.id]);
+
+    const { existingBranches } = getExistingPRIdentifiers(db, false);
+
+    expect(existingBranches.has('feature/open')).toBe(true);
+    expect(existingBranches.has('feature/merged')).toBe(false);
+    expect(existingBranches.has('feature/closed')).toBe(false);
+  });
+
+  it('should collect PR numbers and filter out nulls', () => {
+    createPullRequest(db, { branchName: 'feature/a', githubPrNumber: 42 });
+    createPullRequest(db, { branchName: 'feature/b', githubPrNumber: null });
+    createPullRequest(db, { branchName: 'feature/c', githubPrNumber: 99 });
+
+    const { existingPrNumbers } = getExistingPRIdentifiers(db);
+
+    expect(existingPrNumbers.has(42)).toBe(true);
+    expect(existingPrNumbers.has(99)).toBe(true);
+    expect(existingPrNumbers.size).toBe(2);
+  });
+});
+
+describe('syncOpenGitHubPRs', () => {
+  it('should import new PRs from GitHub', async () => {
+    mockExeca.mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          number: 10,
+          headRefName: 'feature/new-one',
+          url: 'https://github.com/test/repo/pull/10',
+          title: 'New PR',
+        },
+      ]),
+    } as any);
+
+    const result = await syncOpenGitHubPRs(db, '/repo', null, new Set(), new Set());
+
+    expect(result.synced).toBe(1);
+    expect(result.imported).toHaveLength(1);
+    expect(result.imported[0].number).toBe(10);
+    expect(result.imported[0].branch).toBe('feature/new-one');
+  });
+
+  it('should skip PRs with existing branch names', async () => {
+    mockExeca.mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          number: 10,
+          headRefName: 'feature/existing',
+          url: 'https://github.com/test/repo/pull/10',
+          title: 'Existing',
+        },
+        {
+          number: 11,
+          headRefName: 'feature/new',
+          url: 'https://github.com/test/repo/pull/11',
+          title: 'New',
+        },
+      ]),
+    } as any);
+
+    const existingBranches = new Set(['feature/existing']);
+    const result = await syncOpenGitHubPRs(db, '/repo', null, existingBranches, new Set());
+
+    expect(result.synced).toBe(1);
+    expect(result.imported[0].branch).toBe('feature/new');
+  });
+
+  it('should skip PRs with existing PR numbers', async () => {
+    mockExeca.mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          number: 10,
+          headRefName: 'feature/dup-num',
+          url: 'https://github.com/test/repo/pull/10',
+          title: 'Dup',
+        },
+        {
+          number: 11,
+          headRefName: 'feature/new',
+          url: 'https://github.com/test/repo/pull/11',
+          title: 'New',
+        },
+      ]),
+    } as any);
+
+    const existingPrNumbers = new Set([10]);
+    const result = await syncOpenGitHubPRs(db, '/repo', null, new Set(), existingPrNumbers);
+
+    expect(result.synced).toBe(1);
+    expect(result.imported[0].number).toBe(11);
+  });
+
+  it('should return empty results when no new PRs', async () => {
+    mockExeca.mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          number: 10,
+          headRefName: 'feature/existing',
+          url: 'https://github.com/test/repo/pull/10',
+          title: 'Existing',
+        },
+      ]),
+    } as any);
+
+    const existingBranches = new Set(['feature/existing']);
+    const result = await syncOpenGitHubPRs(db, '/repo', null, existingBranches, new Set());
+
+    expect(result.synced).toBe(0);
+    expect(result.imported).toHaveLength(0);
+  });
+
+  it('should associate PRs with provided team ID', async () => {
+    mockExeca.mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          number: 10,
+          headRefName: 'feature/new',
+          url: 'https://github.com/test/repo/pull/10',
+          title: 'New',
+        },
+      ]),
+    } as any);
+
+    // Create a team so foreign key is satisfied
+    db.run(
+      "INSERT INTO teams (id, repo_url, repo_path, name) VALUES ('team-1', 'https://test', 'repo', 'Test')"
+    );
+
+    const result = await syncOpenGitHubPRs(db, '/repo', 'team-1', new Set(), new Set());
+
+    expect(result.synced).toBe(1);
+    // Verify the PR was created with the team ID
+    const prs = db.exec('SELECT team_id FROM pull_requests');
+    expect(prs[0].values[0][0]).toBe('team-1');
+  });
+
+  it('should extract story IDs from branch names that match the story ID pattern', async () => {
+    // Create a story so the FK constraint is satisfied
+    db.run(
+      "INSERT INTO stories (id, title, description, status) VALUES ('STORY-GOD-001', 'Test', 'Test', 'planned')"
+    );
+
+    mockExeca.mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          number: 10,
+          headRefName: 'STORY-GOD-001',
+          url: 'https://github.com/test/repo/pull/10',
+          title: 'Story PR',
+        },
+      ]),
+    } as any);
+
+    await syncOpenGitHubPRs(db, '/repo', null, new Set(), new Set());
+
+    const prs = db.exec('SELECT story_id FROM pull_requests');
+    expect(prs[0].values[0][0]).toBe('STORY-GOD-001');
+  });
+
+  it('should set story_id to null for non-matching branch names', async () => {
+    mockExeca.mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          number: 10,
+          headRefName: 'feature/some-fix',
+          url: 'https://github.com/test/repo/pull/10',
+          title: 'Fix',
+        },
+      ]),
+    } as any);
+
+    await syncOpenGitHubPRs(db, '/repo', null, new Set(), new Set());
+
+    const prs = db.exec('SELECT story_id FROM pull_requests');
+    expect(prs[0].values[0][0]).toBeNull();
+  });
+});

--- a/src/utils/pr-sync.ts
+++ b/src/utils/pr-sync.ts
@@ -1,0 +1,111 @@
+import { execa } from 'execa';
+import type { Database } from 'sql.js';
+import { queryAll, type PullRequestRow } from '../db/client.js';
+import { createPullRequest } from '../db/queries/pull-requests.js';
+import { extractStoryIdFromBranch } from './story-id.js';
+
+export interface GitHubPR {
+  number: number;
+  headRefName: string;
+  url: string;
+  title: string;
+}
+
+export interface SyncedPR {
+  number: number;
+  branch: string;
+  prId: string;
+}
+
+export interface SyncGitHubPRsResult {
+  synced: number;
+  imported: SyncedPR[];
+}
+
+/**
+ * Build sets of existing branch names and PR numbers from the database.
+ *
+ * @param db - sql.js Database instance
+ * @param includeTerminalBranches - If true, include merged/closed PR branches
+ *   in the returned set (prevents re-importing previously synced PRs).
+ *   Defaults to true.
+ */
+export function getExistingPRIdentifiers(
+  db: Database,
+  includeTerminalBranches = true
+): { existingBranches: Set<string>; existingPrNumbers: Set<number> } {
+  const existingPRs = queryAll<PullRequestRow>(db, 'SELECT * FROM pull_requests');
+
+  const existingBranches = new Set(
+    includeTerminalBranches
+      ? existingPRs.map(pr => pr.branch_name)
+      : existingPRs
+          .filter(pr => !['merged', 'closed'].includes(pr.status))
+          .map(pr => pr.branch_name)
+  );
+
+  const existingPrNumbers = new Set(
+    existingPRs.map(pr => pr.github_pr_number).filter((n): n is number => n != null)
+  );
+
+  return { existingBranches, existingPrNumbers };
+}
+
+/**
+ * Fetch open GitHub PRs for a given repository directory.
+ */
+export async function fetchOpenGitHubPRs(repoDir: string): Promise<GitHubPR[]> {
+  const result = await execa(
+    'gh',
+    ['pr', 'list', '--json', 'number,headRefName,url,title', '--state', 'open'],
+    { cwd: repoDir }
+  );
+  return JSON.parse(result.stdout) as GitHubPR[];
+}
+
+/**
+ * Sync open GitHub PRs into the local merge queue.
+ *
+ * Core logic shared between `hive pr sync` CLI command and the manager daemon.
+ *
+ * @param db        - sql.js Database instance
+ * @param repoDir   - Absolute path to the git repository
+ * @param teamId    - Team ID to associate with created PRs (null for CLI usage)
+ * @param existingBranches  - Set of branch names already in the queue
+ * @param existingPrNumbers - Set of GitHub PR numbers already in the queue
+ */
+export async function syncOpenGitHubPRs(
+  db: Database,
+  repoDir: string,
+  teamId: string | null,
+  existingBranches: Set<string>,
+  existingPrNumbers: Set<number>
+): Promise<SyncGitHubPRsResult> {
+  const ghPRs = await fetchOpenGitHubPRs(repoDir);
+  const imported: SyncedPR[] = [];
+
+  for (const ghPR of ghPRs) {
+    if (existingBranches.has(ghPR.headRefName) || existingPrNumbers.has(ghPR.number)) {
+      continue;
+    }
+
+    const storyId = extractStoryIdFromBranch(ghPR.headRefName);
+
+    const pr = createPullRequest(db, {
+      storyId,
+      teamId,
+      branchName: ghPR.headRefName,
+      githubPrNumber: ghPR.number,
+      githubPrUrl: ghPR.url,
+      submittedBy: null,
+    });
+
+    imported.push({
+      number: ghPR.number,
+      branch: ghPR.headRefName,
+      prId: pr.id,
+    });
+  }
+
+  return { synced: imported.length, imported };
+}


### PR DESCRIPTION
## Summary
- Extract worktree removal logic from `scheduler.ts`, `scaler.ts`, and `agents.ts` into shared `src/git/worktree.ts` utility with consistent error handling and configurable timeout
- Extract PR sync logic from `manager.ts` and `pr.ts` into shared `src/utils/pr-sync.ts` with `getExistingPRIdentifiers` and `syncOpenGitHubPRs` functions
- Add 17 new tests covering both shared modules (all 795 tests passing)

Resolves STORY-REF-038

## Test plan
- [x] All 795 tests pass (778 existing + 17 new)
- [x] `src/git/worktree.test.ts` covers success, error, timeout, and edge cases
- [x] `src/utils/pr-sync.test.ts` covers identifier collection, PR import, dedup, and story ID extraction
- [x] Existing scheduler tests updated for new mock approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)