### PR TITLE
fix: format 3 files to restore CI

### DIFF
--- a/src/cli/commands/manager.ts
+++ b/src/cli/commands/manager.ts
@@ -57,9 +57,9 @@ import {
   getAvailableCommands,
   type CLITool,
 } from '../../utils/cli-commands.js';
-import { withHiveContext, withHiveRoot } from '../../utils/with-hive-context.js';
 import { getExistingPRIdentifiers, syncOpenGitHubPRs } from '../../utils/pr-sync.js';
 import { extractStoryIdFromBranch } from '../../utils/story-id.js';
+import { withHiveContext, withHiveRoot } from '../../utils/with-hive-context.js';
 
 // --- Named constants (extracted from inline magic numbers) ---
 

--- a/src/cli/commands/resume.ts
+++ b/src/cli/commands/resume.ts
@@ -17,7 +17,9 @@ export const resumeCommand = new Command('resume')
   .action(async (options: { agent?: string; all?: boolean }) => {
     await withHiveContext(async ({ root, paths, db }) => {
       if (!(await isTmuxAvailable())) {
-        console.error(chalk.red('tmux is not available. Please install tmux to use agent features.'));
+        console.error(
+          chalk.red('tmux is not available. Please install tmux to use agent features.')
+        );
         process.exit(1);
       }
 

--- a/src/utils/with-hive-context.test.ts
+++ b/src/utils/with-hive-context.test.ts
@@ -8,8 +8,15 @@ import { findHiveRoot, getHivePaths } from './paths.js';
 import { withHiveContext, withHiveRoot } from './with-hive-context.js';
 
 describe('withHiveContext', () => {
-  const mockDb = { db: {}, save: vi.fn(), close: vi.fn(), runMigrations: vi.fn() } as unknown as Awaited<ReturnType<typeof getDatabase>>;
-  const mockPaths = { hiveDir: '/mock/.hive', reposDir: '/mock/repos' } as ReturnType<typeof getHivePaths>;
+  const mockDb = {
+    db: {},
+    save: vi.fn(),
+    close: vi.fn(),
+    runMigrations: vi.fn(),
+  } as unknown as Awaited<ReturnType<typeof getDatabase>>;
+  const mockPaths = { hiveDir: '/mock/.hive', reposDir: '/mock/repos' } as ReturnType<
+    typeof getHivePaths
+  >;
 
   beforeEach(() => {
     vi.mocked(findHiveRoot).mockReturnValue('/mock');


### PR DESCRIPTION
## Summary
- CI `format:check` failing on main after STORY-REF-031 merge (PR #215)
- 3 files had Prettier formatting issues: `manager.ts`, `resume.ts`, `with-hive-context.test.ts`
- Ran `prettier --write` on all 3 files

## Test plan
- [x] `prettier --check .` passes
- [x] All 731 tests pass
- [x] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)