### PR TITLE
fix: exclude terminated agents from tmux_session lookups

### DIFF
--- a/src/cli/commands/my-stories.ts
+++ b/src/cli/commands/my-stories.ts
@@ -41,7 +41,7 @@ export const myStoriesCommand = new Command('my-stories')
       // Find agent by tmux session
       const agent = queryOne<{ id: string; team_id: string }>(
         db.db,
-        'SELECT id, team_id FROM agents WHERE tmux_session = ?',
+        "SELECT id, team_id FROM agents WHERE tmux_session = ? AND status != 'terminated'",
         [session]
       );
 
@@ -50,7 +50,7 @@ export const myStoriesCommand = new Command('my-stories')
         console.log(chalk.gray('Available sessions:'));
         const agents = queryAll<{ tmux_session: string }>(
           db.db,
-          'SELECT tmux_session FROM agents WHERE tmux_session IS NOT NULL'
+          "SELECT tmux_session FROM agents WHERE tmux_session IS NOT NULL AND status != 'terminated'"
         );
         for (const a of agents) {
           console.log(chalk.gray(`  - ${a.tmux_session}`));
@@ -119,7 +119,7 @@ myStoriesCommand
       // Find agent by session
       const agent = queryOne<{ id: string }>(
         db.db,
-        'SELECT id FROM agents WHERE tmux_session = ?',
+        "SELECT id FROM agents WHERE tmux_session = ? AND status != 'terminated'",
         [options.session]
       );
 
@@ -235,7 +235,7 @@ myStoriesCommand
       await withHiveContext(async ({ db }) => {
         const agent = queryOne<{ id: string; team_id: string | null }>(
           db.db,
-          'SELECT id, team_id FROM agents WHERE tmux_session = ?',
+          "SELECT id, team_id FROM agents WHERE tmux_session = ? AND status != 'terminated'",
           [options.session]
         );
 


### PR DESCRIPTION
## Summary
- Adds `AND status != 'terminated'` to all four agent-by-session queries in `my-stories.ts`
- When an agent is terminated and a new one spawns with the same tmux session name, the CLI was finding the old terminated agent instead of the active one
- This caused `hive my-stories` to show "No stories assigned", `claim` to fail with "already assigned to another agent", and agents unable to interact with their stories

## Test plan
- [x] All 833 existing tests pass
- [ ] Verify `hive my-stories <session>` correctly finds the active agent when a terminated agent exists with the same session name
- [ ] Verify `hive my-stories claim` works correctly for the active agent
- [ ] Verify `hive my-stories refactor` works correctly for the active agent

Resolves STORY-FIX001

🤖 Generated with [Claude Code](https://claude.com/claude-code)