### PR TITLE
fix: detect already-merged PRs to correctly transition story status

### DIFF
--- a/src/cli/commands/pr.ts
+++ b/src/cli/commands/pr.ts
@@ -316,8 +316,13 @@ prCommand
           console.log(chalk.green(`PR ${prId} approved and merged on GitHub!`));
         } catch (mergeErr: unknown) {
           const errMsg = mergeErr instanceof Error ? mergeErr.message : String(mergeErr);
-          console.log(chalk.yellow(`GitHub merge failed: ${errMsg}`));
-          console.log(chalk.yellow('Marking as approved (manual merge needed).'));
+          if (/already merged/i.test(errMsg)) {
+            actuallyMerged = true;
+            console.log(chalk.green(`PR ${prId} was already merged on GitHub.`));
+          } else {
+            console.log(chalk.yellow(`GitHub merge failed: ${errMsg}`));
+            console.log(chalk.yellow('Marking as approved (manual merge needed).'));
+          }
         }
       } else if (shouldMerge && !pr.github_pr_number) {
         console.log(chalk.yellow('No GitHub PR number linked - marking as approved only.'));


### PR DESCRIPTION
## Summary
- In `pr.ts` approve command, when `gh pr merge` fails with "already merged", the catch block now detects this and sets `actuallyMerged = true`
- Previously, this scenario left the story stuck in `review` status forever because the status was set to `approved` instead of `merged`, and the story update only runs when status is `merged`
- This blocked all dependent stories from proceeding

## Test plan
- [x] All 833 existing tests pass
- [ ] Verify that when a PR is already merged on GitHub, `hive pr approve` correctly transitions the story to `merged` status
- [ ] Verify that non-"already merged" errors still fall through to the `approved` status path

Resolves STORY-FIX002

🤖 Generated with [Claude Code](https://claude.com/claude-code)