### PR TITLE
feat: add read-only database context without file locking

### DIFF
--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -12,7 +12,7 @@ import {
 import { getLogsByAgent } from '../../db/queries/logs.js';
 import { removeWorktree } from '../../git/worktree.js';
 import { statusColor } from '../../utils/logger.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withHiveContext, withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const agentsCommand = new Command('agents').description('Manage agents');
 
@@ -22,7 +22,7 @@ agentsCommand
   .option('--active', 'Show only active agents')
   .option('--json', 'Output as JSON')
   .action(async (options: { active?: boolean; json?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const agents = options.active ? getActiveAgents(db.db) : getAllAgents(db.db);
 
       if (options.json) {
@@ -63,7 +63,7 @@ agentsCommand
   .option('-n, --limit <number>', 'Number of logs to show', '50')
   .option('--json', 'Output as JSON')
   .action(async (agentId: string, options: { limit: string; json?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const agent = getAgentById(db.db, agentId);
       if (!agent) {
         console.error(chalk.red(`Agent not found: ${agentId}`));
@@ -108,7 +108,7 @@ agentsCommand
   .command('inspect <agent-id>')
   .description('View detailed agent state')
   .action(async (agentId: string) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const agent = getAgentById(db.db, agentId);
       if (!agent) {
         console.error(chalk.red(`Agent not found: ${agentId}`));

--- a/src/cli/commands/escalations.ts
+++ b/src/cli/commands/escalations.ts
@@ -10,7 +10,7 @@ import {
   resolveEscalation,
 } from '../../db/queries/escalations.js';
 import { createLog } from '../../db/queries/logs.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withHiveContext, withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const escalationsCommand = new Command('escalations').description('Manage escalations');
 
@@ -20,7 +20,7 @@ escalationsCommand
   .option('--all', 'Show all escalations (including resolved)')
   .option('--json', 'Output as JSON')
   .action(async (options: { all?: boolean; json?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const escalations = options.all ? getAllEscalations(db.db) : getPendingEscalations(db.db);
 
       if (options.json) {
@@ -63,7 +63,7 @@ escalationsCommand
   .command('show <id>')
   .description('Show escalation details')
   .action(async (id: string) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const escalation = getEscalationById(db.db, id);
       if (!escalation) {
         console.error(chalk.red(`Escalation not found: ${id}`));

--- a/src/cli/commands/msg.ts
+++ b/src/cli/commands/msg.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 import { nanoid } from 'nanoid';
 import { queryAll, queryOne, run } from '../../db/client.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withHiveContext, withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 interface MessageRow {
   id: string;
@@ -53,7 +53,7 @@ msgCommand
   .description('Check inbox for messages')
   .option('--all', 'Show all messages including read')
   .action(async (session: string | undefined, options: { all?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const targetSession = session || 'hive-tech-lead';
 
       let query = `
@@ -165,7 +165,7 @@ msgCommand
   .command('outbox [session]')
   .description('Check sent messages and their replies')
   .action(async (session: string | undefined) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const fromSession = session || 'hive-tech-lead';
 
       const messages = queryAll<MessageRow>(

--- a/src/cli/commands/my-stories.ts
+++ b/src/cli/commands/my-stories.ts
@@ -5,14 +5,14 @@ import { Command } from 'commander';
 import { queryAll, queryOne, run, type StoryRow } from '../../db/client.js';
 import { createLog } from '../../db/queries/logs.js';
 import { createStory, getStoryDependencies, updateStory } from '../../db/queries/stories.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withHiveContext, withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const myStoriesCommand = new Command('my-stories')
   .description('View and manage stories assigned to an agent')
   .argument('[session]', 'Tmux session name (e.g., hive-senior-myteam)')
   .option('--all', 'Show all stories for the team, not just assigned')
   .action(async (session: string | undefined, options: { all?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       if (!session) {
         // Show all in-progress stories
         const stories = queryAll<StoryRow & { tmux_session?: string }>(

--- a/src/cli/commands/pr.ts
+++ b/src/cli/commands/pr.ts
@@ -23,7 +23,7 @@ import { isTmuxSessionRunning, sendToTmuxSession } from '../../tmux/manager.js';
 import { autoMergeApprovedPRs } from '../../utils/auto-merge.js';
 import { getExistingPRIdentifiers, syncOpenGitHubPRs } from '../../utils/pr-sync.js';
 import { extractStoryIdFromBranch, normalizeStoryId } from '../../utils/story-id.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withHiveContext, withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const prCommand = new Command('pr').description('Manage pull requests and merge queue');
 
@@ -170,7 +170,7 @@ prCommand
   .option('-t, --team <team-id>', 'Filter by team')
   .option('--json', 'Output as JSON')
   .action(async (options: { team?: string; json?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const queue = getMergeQueue(db.db, options.team);
 
       if (options.json) {
@@ -256,7 +256,7 @@ prCommand
   .command('show <pr-id>')
   .description('View details of a PR')
   .action(async (prId: string) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const pr = getPullRequestById(db.db, prId);
       if (!pr) {
         console.error(chalk.red(`PR not found: ${prId}`));

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -14,7 +14,7 @@ import {
 } from '../../db/queries/stories.js';
 import { getAllTeams, getTeamByName } from '../../db/queries/teams.js';
 import { statusColor } from '../../utils/logger.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const statusCommand = new Command('status')
   .description('Show Hive status')
@@ -22,7 +22,7 @@ export const statusCommand = new Command('status')
   .option('--story <id>', 'Show status for a specific story')
   .option('--json', 'Output as JSON')
   .action(async (options: { team?: string; story?: string; json?: boolean }) => {
-    await withHiveContext(({ db }) => {
+    await withReadOnlyHiveContext(({ db }) => {
       if (options.story) {
         showStoryStatus(db.db, options.story, options.json);
       } else if (options.team) {

--- a/src/cli/commands/stories.ts
+++ b/src/cli/commands/stories.ts
@@ -10,7 +10,7 @@ import {
   type StoryStatus,
 } from '../../db/queries/stories.js';
 import { statusColor } from '../../utils/logger.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const storiesCommand = new Command('stories').description('Manage stories');
 
@@ -20,7 +20,7 @@ storiesCommand
   .option('--status <status>', 'Filter by status')
   .option('--json', 'Output as JSON')
   .action(async (options: { status?: string; json?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       let stories;
       if (options.status) {
         stories = getStoriesByStatus(db.db, options.status as StoryStatus);
@@ -65,7 +65,7 @@ storiesCommand
   .command('show <story-id>')
   .description('Show story details')
   .action(async (storyId: string) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const story = getStoryById(db.db, storyId);
       if (!story) {
         console.error(chalk.red(`Story not found: ${storyId}`));

--- a/src/cli/commands/teams.ts
+++ b/src/cli/commands/teams.ts
@@ -5,7 +5,7 @@ import { Command } from 'commander';
 import { getAgentsByTeam } from '../../db/queries/agents.js';
 import { getStoriesByTeam, getStoryPointsByTeam } from '../../db/queries/stories.js';
 import { deleteTeam, getAllTeams, getTeamByName } from '../../db/queries/teams.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withHiveContext, withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const teamsCommand = new Command('teams').description('Manage teams');
 
@@ -14,7 +14,7 @@ teamsCommand
   .description('List all teams')
   .option('--json', 'Output as JSON')
   .action(async (options: { json?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const teams = getAllTeams(db.db);
 
       if (options.json) {
@@ -51,7 +51,7 @@ teamsCommand
   .command('show <name>')
   .description('Show team details')
   .action(async (name: string) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const team = getTeamByName(db.db, name);
 
       if (!team) {

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -115,6 +115,16 @@ export class DatabaseCorruptionError extends HiveError {
 }
 
 /**
+ * Read-only database violation errors (write attempted on read-only context)
+ */
+export class ReadOnlyDatabaseError extends HiveError {
+  constructor(message: string = 'Cannot perform write operations on a read-only database context') {
+    super(message, 'READ_ONLY_DATABASE_ERROR');
+    Object.setPrototypeOf(this, ReadOnlyDatabaseError.prototype);
+  }
+}
+
+/**
  * Helper function to convert generic errors to Hive errors
  */
 export function toHiveError(error: unknown, fallbackType: typeof HiveError = HiveError): HiveError {

--- a/src/utils/with-hive-context.test.ts
+++ b/src/utils/with-hive-context.test.ts
@@ -6,10 +6,10 @@ vi.mock('../db/client.js');
 vi.mock('../db/lock.js');
 vi.mock('./paths.js');
 
-import { getDatabase } from '../db/client.js';
+import { getDatabase, getReadOnlyDatabase } from '../db/client.js';
 import { acquireLock } from '../db/lock.js';
 import { findHiveRoot, getHivePaths } from './paths.js';
-import { withHiveContext, withHiveRoot } from './with-hive-context.js';
+import { withHiveContext, withHiveRoot, withReadOnlyHiveContext } from './with-hive-context.js';
 
 describe('withHiveContext', () => {
   const mockDb = {
@@ -92,6 +92,79 @@ describe('withHiveContext', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     await expect(withHiveContext(() => {})).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    exitSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('withReadOnlyHiveContext', () => {
+  const mockReadOnlyDb = {
+    db: {},
+    close: vi.fn(),
+  } as unknown as Awaited<ReturnType<typeof getReadOnlyDatabase>>;
+  const mockPaths = { hiveDir: '/mock/.hive', reposDir: '/mock/repos' } as ReturnType<
+    typeof getHivePaths
+  >;
+
+  beforeEach(() => {
+    vi.mocked(findHiveRoot).mockReturnValue('/mock');
+    vi.mocked(getHivePaths).mockReturnValue(mockPaths);
+    vi.mocked(getReadOnlyDatabase).mockResolvedValue(mockReadOnlyDb);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('provides root, paths, and db to callback', async () => {
+    await withReadOnlyHiveContext(ctx => {
+      expect(ctx.root).toBe('/mock');
+      expect(ctx.paths).toBe(mockPaths);
+      expect(ctx.db).toBe(mockReadOnlyDb);
+    });
+  });
+
+  it('returns the callback result', async () => {
+    const result = await withReadOnlyHiveContext(() => 42);
+    expect(result).toBe(42);
+  });
+
+  it('does not acquire a file lock', async () => {
+    await withReadOnlyHiveContext(() => {});
+    expect(acquireLock).not.toHaveBeenCalled();
+  });
+
+  it('closes db after callback completes', async () => {
+    await withReadOnlyHiveContext(() => {});
+    expect(mockReadOnlyDb.close).toHaveBeenCalledOnce();
+  });
+
+  it('closes db even if callback throws', async () => {
+    await expect(
+      withReadOnlyHiveContext(() => {
+        throw new Error('test');
+      })
+    ).rejects.toThrow('test');
+    expect(mockReadOnlyDb.close).toHaveBeenCalledOnce();
+  });
+
+  it('works with async callbacks', async () => {
+    const result = await withReadOnlyHiveContext(async () => {
+      return Promise.resolve('async-result');
+    });
+    expect(result).toBe('async-result');
+  });
+
+  it('exits when not in a Hive workspace', async () => {
+    vi.mocked(findHiveRoot).mockReturnValue(null);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(withReadOnlyHiveContext(() => {})).rejects.toThrow('process.exit');
     expect(exitSpy).toHaveBeenCalledWith(1);
 
     exitSpy.mockRestore();


### PR DESCRIPTION
## Summary
- Add `withReadOnlyHiveContext()` that loads the DB snapshot without acquiring the exclusive file lock, reducing contention when multiple agents run concurrently
- Write operations on the read-only context are intercepted via a Proxy and throw `ReadOnlyDatabaseError`
- Convert 14 read-only CLI command actions to use the lock-free context: status, stories list/show, teams list/show, agents list/logs/inspect, escalations list/show, pr queue/show, msg inbox/outbox, my-stories list

Resolves [HIVE-OPT-001]

## Test plan
- [x] All 869 existing tests pass (no regressions)
- [x] 18 new tests added covering withReadOnlyHiveContext and createReadOnlyDatabase
- [x] Read-only proxy correctly blocks INSERT, UPDATE, DELETE, CREATE, DROP operations
- [x] Read-only proxy allows SELECT and PRAGMA queries
- [x] No merge conflicts with main

🤖 Generated with [Claude Code](https://claude.com/claude-code)