### PR TITLE
feat: add read-only database context without file locking

### DIFF
--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -12,7 +12,7 @@ import {
 import { getLogsByAgent } from '../../db/queries/logs.js';
 import { removeWorktree } from '../../git/worktree.js';
 import { statusColor } from '../../utils/logger.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withHiveContext, withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const agentsCommand = new Command('agents').description('Manage agents');
 
@@ -22,7 +22,7 @@ agentsCommand
   .option('--active', 'Show only active agents')
   .option('--json', 'Output as JSON')
   .action(async (options: { active?: boolean; json?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const agents = options.active ? getActiveAgents(db.db) : getAllAgents(db.db);
 
       if (options.json) {
@@ -63,7 +63,7 @@ agentsCommand
   .option('-n, --limit <number>', 'Number of logs to show', '50')
   .option('--json', 'Output as JSON')
   .action(async (agentId: string, options: { limit: string; json?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const agent = getAgentById(db.db, agentId);
       if (!agent) {
         console.error(chalk.red(`Agent not found: ${agentId}`));
@@ -108,7 +108,7 @@ agentsCommand
   .command('inspect <agent-id>')
   .description('View detailed agent state')
   .action(async (agentId: string) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const agent = getAgentById(db.db, agentId);
       if (!agent) {
         console.error(chalk.red(`Agent not found: ${agentId}`));

--- a/src/cli/commands/escalations.ts
+++ b/src/cli/commands/escalations.ts
@@ -10,7 +10,7 @@ import {
   resolveEscalation,
 } from '../../db/queries/escalations.js';
 import { createLog } from '../../db/queries/logs.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withHiveContext, withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const escalationsCommand = new Command('escalations').description('Manage escalations');
 
@@ -20,7 +20,7 @@ escalationsCommand
   .option('--all', 'Show all escalations (including resolved)')
   .option('--json', 'Output as JSON')
   .action(async (options: { all?: boolean; json?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const escalations = options.all ? getAllEscalations(db.db) : getPendingEscalations(db.db);
 
       if (options.json) {
@@ -63,7 +63,7 @@ escalationsCommand
   .command('show <id>')
   .description('Show escalation details')
   .action(async (id: string) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const escalation = getEscalationById(db.db, id);
       if (!escalation) {
         console.error(chalk.red(`Escalation not found: ${id}`));

--- a/src/cli/commands/msg.ts
+++ b/src/cli/commands/msg.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 import { nanoid } from 'nanoid';
 import { queryAll, queryOne, run } from '../../db/client.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withHiveContext, withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 interface MessageRow {
   id: string;
@@ -53,7 +53,7 @@ msgCommand
   .description('Check inbox for messages')
   .option('--all', 'Show all messages including read')
   .action(async (session: string | undefined, options: { all?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const targetSession = session || 'hive-tech-lead';
 
       let query = `
@@ -165,7 +165,7 @@ msgCommand
   .command('outbox [session]')
   .description('Check sent messages and their replies')
   .action(async (session: string | undefined) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const fromSession = session || 'hive-tech-lead';
 
       const messages = queryAll<MessageRow>(

--- a/src/cli/commands/my-stories.ts
+++ b/src/cli/commands/my-stories.ts
@@ -5,14 +5,14 @@ import { Command } from 'commander';
 import { queryAll, queryOne, run, type StoryRow } from '../../db/client.js';
 import { createLog } from '../../db/queries/logs.js';
 import { createStory, getStoryDependencies, updateStory } from '../../db/queries/stories.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withHiveContext, withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const myStoriesCommand = new Command('my-stories')
   .description('View and manage stories assigned to an agent')
   .argument('[session]', 'Tmux session name (e.g., hive-senior-myteam)')
   .option('--all', 'Show all stories for the team, not just assigned')
   .action(async (session: string | undefined, options: { all?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       if (!session) {
         // Show all in-progress stories
         const stories = queryAll<StoryRow & { tmux_session?: string }>(

--- a/src/cli/commands/pr.ts
+++ b/src/cli/commands/pr.ts
@@ -23,7 +23,7 @@ import { isTmuxSessionRunning, sendToTmuxSession } from '../../tmux/manager.js';
 import { autoMergeApprovedPRs } from '../../utils/auto-merge.js';
 import { getExistingPRIdentifiers, syncOpenGitHubPRs } from '../../utils/pr-sync.js';
 import { extractStoryIdFromBranch, normalizeStoryId } from '../../utils/story-id.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withHiveContext, withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const prCommand = new Command('pr').description('Manage pull requests and merge queue');
 
@@ -170,7 +170,7 @@ prCommand
   .option('-t, --team <team-id>', 'Filter by team')
   .option('--json', 'Output as JSON')
   .action(async (options: { team?: string; json?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const queue = getMergeQueue(db.db, options.team);
 
       if (options.json) {
@@ -256,7 +256,7 @@ prCommand
   .command('show <pr-id>')
   .description('View details of a PR')
   .action(async (prId: string) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const pr = getPullRequestById(db.db, prId);
       if (!pr) {
         console.error(chalk.red(`PR not found: ${prId}`));

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -14,7 +14,7 @@ import {
 } from '../../db/queries/stories.js';
 import { getAllTeams, getTeamByName } from '../../db/queries/teams.js';
 import { statusColor } from '../../utils/logger.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const statusCommand = new Command('status')
   .description('Show Hive status')
@@ -22,7 +22,7 @@ export const statusCommand = new Command('status')
   .option('--story <id>', 'Show status for a specific story')
   .option('--json', 'Output as JSON')
   .action(async (options: { team?: string; story?: string; json?: boolean }) => {
-    await withHiveContext(({ db }) => {
+    await withReadOnlyHiveContext(({ db }) => {
       if (options.story) {
         showStoryStatus(db.db, options.story, options.json);
       } else if (options.team) {

--- a/src/cli/commands/stories.ts
+++ b/src/cli/commands/stories.ts
@@ -10,7 +10,7 @@ import {
   type StoryStatus,
 } from '../../db/queries/stories.js';
 import { statusColor } from '../../utils/logger.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const storiesCommand = new Command('stories').description('Manage stories');
 
@@ -20,7 +20,7 @@ storiesCommand
   .option('--status <status>', 'Filter by status')
   .option('--json', 'Output as JSON')
   .action(async (options: { status?: string; json?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       let stories;
       if (options.status) {
         stories = getStoriesByStatus(db.db, options.status as StoryStatus);
@@ -65,7 +65,7 @@ storiesCommand
   .command('show <story-id>')
   .description('Show story details')
   .action(async (storyId: string) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const story = getStoryById(db.db, storyId);
       if (!story) {
         console.error(chalk.red(`Story not found: ${storyId}`));

--- a/src/cli/commands/teams.ts
+++ b/src/cli/commands/teams.ts
@@ -5,7 +5,7 @@ import { Command } from 'commander';
 import { getAgentsByTeam } from '../../db/queries/agents.js';
 import { getStoriesByTeam, getStoryPointsByTeam } from '../../db/queries/stories.js';
 import { deleteTeam, getAllTeams, getTeamByName } from '../../db/queries/teams.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withHiveContext, withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const teamsCommand = new Command('teams').description('Manage teams');
 
@@ -14,7 +14,7 @@ teamsCommand
   .description('List all teams')
   .option('--json', 'Output as JSON')
   .action(async (options: { json?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const teams = getAllTeams(db.db);
 
       if (options.json) {
@@ -51,7 +51,7 @@ teamsCommand
   .command('show <name>')
   .description('Show team details')
   .action(async (name: string) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const team = getTeamByName(db.db, name);
 
       if (!team) {

--- a/src/db/client.test.ts
+++ b/src/db/client.test.ts
@@ -3,8 +3,8 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import initSqlJs from 'sql.js';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { DatabaseCorruptionError } from '../errors/index.js';
-import { createDatabase } from './client.js';
+import { DatabaseCorruptionError, ReadOnlyAccessError } from '../errors/index.js';
+import { createDatabase, createReadOnlyDatabase } from './client.js';
 
 /**
  * Helper to create a valid SQLite database buffer with the core schema
@@ -345,5 +345,121 @@ describe('createDatabase', () => {
 
       client.close();
     });
+  });
+});
+
+describe('createReadOnlyDatabase', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'hive-ro-db-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should load an existing database for reading', async () => {
+    const dbPath = join(tempDir, 'readonly.db');
+    const data = await createValidDbBuffer({ withData: true });
+    writeFileSync(dbPath, Buffer.from(data));
+
+    const client = await createReadOnlyDatabase(dbPath);
+    const result = client.db.exec('SELECT COUNT(*) FROM teams');
+    expect(result[0].values[0][0]).toBe(1);
+
+    client.close();
+  });
+
+  it('should allow read queries via prepare/exec', async () => {
+    const dbPath = join(tempDir, 'readonly-query.db');
+    const data = await createValidDbBuffer({ withData: true });
+    writeFileSync(dbPath, Buffer.from(data));
+
+    const client = await createReadOnlyDatabase(dbPath);
+
+    // exec should work for reads
+    const result = client.db.exec('SELECT name FROM teams');
+    expect(result[0].values[0][0]).toBe('Test Team');
+
+    // prepare should work for reads
+    const stmt = client.db.prepare('SELECT COUNT(*) as cnt FROM teams');
+    stmt.step();
+    const row = stmt.getAsObject();
+    expect(row.cnt).toBe(1);
+    stmt.free();
+
+    client.close();
+  });
+
+  it('should throw ReadOnlyAccessError on db.run()', async () => {
+    const dbPath = join(tempDir, 'readonly-run.db');
+    const data = await createValidDbBuffer({ withData: true });
+    writeFileSync(dbPath, Buffer.from(data));
+
+    const client = await createReadOnlyDatabase(dbPath);
+
+    expect(() => {
+      client.db.run("INSERT INTO teams VALUES ('t2', 'url', '/path', 'Team2', datetime('now'))");
+    }).toThrow(ReadOnlyAccessError);
+
+    client.close();
+  });
+
+  it('should throw ReadOnlyAccessError on save()', async () => {
+    const dbPath = join(tempDir, 'readonly-save.db');
+    const data = await createValidDbBuffer({ withData: true });
+    writeFileSync(dbPath, Buffer.from(data));
+
+    const client = await createReadOnlyDatabase(dbPath);
+
+    expect(() => client.save()).toThrow(ReadOnlyAccessError);
+
+    client.close();
+  });
+
+  it('should throw ReadOnlyAccessError on runMigrations()', async () => {
+    const dbPath = join(tempDir, 'readonly-migrations.db');
+    const data = await createValidDbBuffer({ withData: true });
+    writeFileSync(dbPath, Buffer.from(data));
+
+    const client = await createReadOnlyDatabase(dbPath);
+
+    expect(() => client.runMigrations()).toThrow(ReadOnlyAccessError);
+
+    client.close();
+  });
+
+  it('should not modify the file on disk', async () => {
+    const dbPath = join(tempDir, 'readonly-nowrite.db');
+    const data = await createValidDbBuffer({ withData: true });
+    writeFileSync(dbPath, Buffer.from(data));
+
+    const originalContent = readFileSync(dbPath);
+
+    const client = await createReadOnlyDatabase(dbPath);
+    client.db.exec('SELECT * FROM teams');
+    client.close();
+
+    const afterContent = readFileSync(dbPath);
+    expect(afterContent).toEqual(originalContent);
+  });
+
+  it('should create empty database when file does not exist', async () => {
+    const dbPath = join(tempDir, 'nonexistent.db');
+    const client = await createReadOnlyDatabase(dbPath);
+
+    expect(client.db).toBeDefined();
+
+    client.close();
+  });
+
+  it('should detect corruption same as createDatabase', async () => {
+    const dbPath = join(tempDir, 'readonly-corrupt.db');
+    const garbageBuffer = Buffer.alloc(100);
+    garbageBuffer.write('NOT_A_SQLITE_DATABASE', 0);
+    writeFileSync(dbPath, garbageBuffer);
+
+    await expect(createReadOnlyDatabase(dbPath)).rejects.toThrow(DatabaseCorruptionError);
   });
 });

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -115,6 +115,16 @@ export class DatabaseCorruptionError extends HiveError {
 }
 
 /**
+ * Read-only access errors (write attempted on a read-only database context)
+ */
+export class ReadOnlyAccessError extends HiveError {
+  constructor(message: string = 'Cannot perform write operations on a read-only database context') {
+    super(message, 'READ_ONLY_ACCESS_ERROR');
+    Object.setPrototypeOf(this, ReadOnlyAccessError.prototype);
+  }
+}
+
+/**
  * Helper function to convert generic errors to Hive errors
  */
 export function toHiveError(error: unknown, fallbackType: typeof HiveError = HiveError): HiveError {

--- a/src/utils/with-hive-context.test.ts
+++ b/src/utils/with-hive-context.test.ts
@@ -6,10 +6,10 @@ vi.mock('../db/client.js');
 vi.mock('../db/lock.js');
 vi.mock('./paths.js');
 
-import { getDatabase } from '../db/client.js';
+import { getDatabase, getReadOnlyDatabase } from '../db/client.js';
 import { acquireLock } from '../db/lock.js';
 import { findHiveRoot, getHivePaths } from './paths.js';
-import { withHiveContext, withHiveRoot } from './with-hive-context.js';
+import { withHiveContext, withHiveRoot, withReadOnlyHiveContext } from './with-hive-context.js';
 
 describe('withHiveContext', () => {
   const mockDb = {
@@ -92,6 +92,81 @@ describe('withHiveContext', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     await expect(withHiveContext(() => {})).rejects.toThrow('process.exit');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    exitSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+});
+
+describe('withReadOnlyHiveContext', () => {
+  const mockReadOnlyDb = {
+    db: {},
+    save: vi.fn(),
+    close: vi.fn(),
+    runMigrations: vi.fn(),
+  } as unknown as Awaited<ReturnType<typeof getReadOnlyDatabase>>;
+  const mockPaths = { hiveDir: '/mock/.hive', reposDir: '/mock/repos' } as ReturnType<
+    typeof getHivePaths
+  >;
+
+  beforeEach(() => {
+    vi.mocked(findHiveRoot).mockReturnValue('/mock');
+    vi.mocked(getHivePaths).mockReturnValue(mockPaths);
+    vi.mocked(getReadOnlyDatabase).mockResolvedValue(mockReadOnlyDb);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('provides root, paths, and db to callback', async () => {
+    await withReadOnlyHiveContext(ctx => {
+      expect(ctx.root).toBe('/mock');
+      expect(ctx.paths).toBe(mockPaths);
+      expect(ctx.db).toBe(mockReadOnlyDb);
+    });
+  });
+
+  it('returns the callback result', async () => {
+    const result = await withReadOnlyHiveContext(() => 42);
+    expect(result).toBe(42);
+  });
+
+  it('closes db after callback completes', async () => {
+    await withReadOnlyHiveContext(() => {});
+    expect(mockReadOnlyDb.close).toHaveBeenCalledOnce();
+  });
+
+  it('closes db even if callback throws', async () => {
+    await expect(
+      withReadOnlyHiveContext(() => {
+        throw new Error('test');
+      })
+    ).rejects.toThrow('test');
+    expect(mockReadOnlyDb.close).toHaveBeenCalledOnce();
+  });
+
+  it('does not acquire any file lock', async () => {
+    await withReadOnlyHiveContext(() => {});
+    expect(acquireLock).not.toHaveBeenCalled();
+  });
+
+  it('works with async callbacks', async () => {
+    const result = await withReadOnlyHiveContext(async () => {
+      return Promise.resolve('async-result');
+    });
+    expect(result).toBe('async-result');
+  });
+
+  it('exits when not in a Hive workspace', async () => {
+    vi.mocked(findHiveRoot).mockReturnValue(null);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(withReadOnlyHiveContext(() => {})).rejects.toThrow('process.exit');
     expect(exitSpy).toHaveBeenCalledWith(1);
 
     exitSpy.mockRestore();

--- a/src/utils/with-hive-context.ts
+++ b/src/utils/with-hive-context.ts
@@ -2,7 +2,7 @@
 
 import chalk from 'chalk';
 import { join } from 'path';
-import { getDatabase, type DatabaseClient } from '../db/client.js';
+import { getDatabase, getReadOnlyDatabase, type DatabaseClient } from '../db/client.js';
 import { acquireLock } from '../db/lock.js';
 import { findHiveRoot, getHivePaths, type HivePaths } from './paths.js';
 
@@ -58,6 +58,19 @@ export async function withHiveContext<T>(fn: (ctx: HiveContext) => Promise<T> | 
     if (releaseLock) {
       await releaseLock();
     }
+  }
+}
+
+export async function withReadOnlyHiveContext<T>(
+  fn: (ctx: HiveContext) => Promise<T> | T
+): Promise<T> {
+  const { root, paths } = resolveRoot();
+
+  const db = await getReadOnlyDatabase(paths.hiveDir);
+  try {
+    return await fn({ root, paths, db });
+  } finally {
+    db.close();
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `withReadOnlyHiveContext()` that loads the database snapshot without acquiring the exclusive file lock, eliminating lock contention for read-only CLI commands
- Adds `ReadOnlyAccessError` and `createReadOnlyDatabase()` that throws on any write attempt (`db.run()`, `save()`, `runMigrations()`)
- Converts 14 read-only CLI subcommands across 8 command files: `status`, `stories list/show`, `agents list/logs/inspect`, `teams list/show`, `msg inbox/outbox`, `pr queue/show`, `escalations list/show`, `my-stories` (default listing)

## Test plan
- [x] All 865 existing tests pass
- [x] 7 new tests for `withReadOnlyHiveContext` (callback behavior, no lock acquired, error handling)
- [x] 8 new tests for `createReadOnlyDatabase` (read queries work, write operations throw `ReadOnlyAccessError`, file not modified, corruption detection)
- [x] ESLint passes with no errors
- [x] No merge conflicts with main

[HIVE-OPT-001]

🤖 Generated with [Claude Code](https://claude.com/claude-code)