### PR TITLE
feat: add read-only database context without file locking

### DIFF
--- a/src/cli/commands/agents.ts
+++ b/src/cli/commands/agents.ts
@@ -12,7 +12,7 @@ import {
 import { getLogsByAgent } from '../../db/queries/logs.js';
 import { removeWorktree } from '../../git/worktree.js';
 import { statusColor } from '../../utils/logger.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withHiveContext, withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const agentsCommand = new Command('agents').description('Manage agents');
 
@@ -22,7 +22,7 @@ agentsCommand
   .option('--active', 'Show only active agents')
   .option('--json', 'Output as JSON')
   .action(async (options: { active?: boolean; json?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const agents = options.active ? getActiveAgents(db.db) : getAllAgents(db.db);
 
       if (options.json) {
@@ -63,7 +63,7 @@ agentsCommand
   .option('-n, --limit <number>', 'Number of logs to show', '50')
   .option('--json', 'Output as JSON')
   .action(async (agentId: string, options: { limit: string; json?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const agent = getAgentById(db.db, agentId);
       if (!agent) {
         console.error(chalk.red(`Agent not found: ${agentId}`));
@@ -108,7 +108,7 @@ agentsCommand
   .command('inspect <agent-id>')
   .description('View detailed agent state')
   .action(async (agentId: string) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const agent = getAgentById(db.db, agentId);
       if (!agent) {
         console.error(chalk.red(`Agent not found: ${agentId}`));

--- a/src/cli/commands/escalations.ts
+++ b/src/cli/commands/escalations.ts
@@ -10,7 +10,7 @@ import {
   resolveEscalation,
 } from '../../db/queries/escalations.js';
 import { createLog } from '../../db/queries/logs.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withHiveContext, withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const escalationsCommand = new Command('escalations').description('Manage escalations');
 
@@ -20,7 +20,7 @@ escalationsCommand
   .option('--all', 'Show all escalations (including resolved)')
   .option('--json', 'Output as JSON')
   .action(async (options: { all?: boolean; json?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const escalations = options.all ? getAllEscalations(db.db) : getPendingEscalations(db.db);
 
       if (options.json) {
@@ -63,7 +63,7 @@ escalationsCommand
   .command('show <id>')
   .description('Show escalation details')
   .action(async (id: string) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const escalation = getEscalationById(db.db, id);
       if (!escalation) {
         console.error(chalk.red(`Escalation not found: ${id}`));

--- a/src/cli/commands/msg.ts
+++ b/src/cli/commands/msg.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 import { nanoid } from 'nanoid';
 import { queryAll, queryOne, run } from '../../db/client.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withHiveContext, withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 interface MessageRow {
   id: string;
@@ -53,7 +53,7 @@ msgCommand
   .description('Check inbox for messages')
   .option('--all', 'Show all messages including read')
   .action(async (session: string | undefined, options: { all?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const targetSession = session || 'hive-tech-lead';
 
       let query = `
@@ -165,7 +165,7 @@ msgCommand
   .command('outbox [session]')
   .description('Check sent messages and their replies')
   .action(async (session: string | undefined) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const fromSession = session || 'hive-tech-lead';
 
       const messages = queryAll<MessageRow>(

--- a/src/cli/commands/my-stories.ts
+++ b/src/cli/commands/my-stories.ts
@@ -5,14 +5,14 @@ import { Command } from 'commander';
 import { queryAll, queryOne, run, type StoryRow } from '../../db/client.js';
 import { createLog } from '../../db/queries/logs.js';
 import { createStory, getStoryDependencies, updateStory } from '../../db/queries/stories.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withHiveContext, withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const myStoriesCommand = new Command('my-stories')
   .description('View and manage stories assigned to an agent')
   .argument('[session]', 'Tmux session name (e.g., hive-senior-myteam)')
   .option('--all', 'Show all stories for the team, not just assigned')
   .action(async (session: string | undefined, options: { all?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       if (!session) {
         // Show all in-progress stories
         const stories = queryAll<StoryRow & { tmux_session?: string }>(

--- a/src/cli/commands/pr.ts
+++ b/src/cli/commands/pr.ts
@@ -23,7 +23,7 @@ import { isTmuxSessionRunning, sendToTmuxSession } from '../../tmux/manager.js';
 import { autoMergeApprovedPRs } from '../../utils/auto-merge.js';
 import { getExistingPRIdentifiers, syncOpenGitHubPRs } from '../../utils/pr-sync.js';
 import { extractStoryIdFromBranch, normalizeStoryId } from '../../utils/story-id.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withHiveContext, withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const prCommand = new Command('pr').description('Manage pull requests and merge queue');
 
@@ -170,7 +170,7 @@ prCommand
   .option('-t, --team <team-id>', 'Filter by team')
   .option('--json', 'Output as JSON')
   .action(async (options: { team?: string; json?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const queue = getMergeQueue(db.db, options.team);
 
       if (options.json) {
@@ -256,7 +256,7 @@ prCommand
   .command('show <pr-id>')
   .description('View details of a PR')
   .action(async (prId: string) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const pr = getPullRequestById(db.db, prId);
       if (!pr) {
         console.error(chalk.red(`PR not found: ${prId}`));

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -14,7 +14,7 @@ import {
 } from '../../db/queries/stories.js';
 import { getAllTeams, getTeamByName } from '../../db/queries/teams.js';
 import { statusColor } from '../../utils/logger.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const statusCommand = new Command('status')
   .description('Show Hive status')
@@ -22,7 +22,7 @@ export const statusCommand = new Command('status')
   .option('--story <id>', 'Show status for a specific story')
   .option('--json', 'Output as JSON')
   .action(async (options: { team?: string; story?: string; json?: boolean }) => {
-    await withHiveContext(({ db }) => {
+    await withReadOnlyHiveContext(({ db }) => {
       if (options.story) {
         showStoryStatus(db.db, options.story, options.json);
       } else if (options.team) {

--- a/src/cli/commands/stories.ts
+++ b/src/cli/commands/stories.ts
@@ -10,7 +10,7 @@ import {
   type StoryStatus,
 } from '../../db/queries/stories.js';
 import { statusColor } from '../../utils/logger.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const storiesCommand = new Command('stories').description('Manage stories');
 
@@ -20,7 +20,7 @@ storiesCommand
   .option('--status <status>', 'Filter by status')
   .option('--json', 'Output as JSON')
   .action(async (options: { status?: string; json?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       let stories;
       if (options.status) {
         stories = getStoriesByStatus(db.db, options.status as StoryStatus);
@@ -65,7 +65,7 @@ storiesCommand
   .command('show <story-id>')
   .description('Show story details')
   .action(async (storyId: string) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const story = getStoryById(db.db, storyId);
       if (!story) {
         console.error(chalk.red(`Story not found: ${storyId}`));

--- a/src/cli/commands/teams.ts
+++ b/src/cli/commands/teams.ts
@@ -5,7 +5,7 @@ import { Command } from 'commander';
 import { getAgentsByTeam } from '../../db/queries/agents.js';
 import { getStoriesByTeam, getStoryPointsByTeam } from '../../db/queries/stories.js';
 import { deleteTeam, getAllTeams, getTeamByName } from '../../db/queries/teams.js';
-import { withHiveContext } from '../../utils/with-hive-context.js';
+import { withHiveContext, withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const teamsCommand = new Command('teams').description('Manage teams');
 
@@ -14,7 +14,7 @@ teamsCommand
   .description('List all teams')
   .option('--json', 'Output as JSON')
   .action(async (options: { json?: boolean }) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const teams = getAllTeams(db.db);
 
       if (options.json) {
@@ -51,7 +51,7 @@ teamsCommand
   .command('show <name>')
   .description('Show team details')
   .action(async (name: string) => {
-    await withHiveContext(async ({ db }) => {
+    await withReadOnlyHiveContext(async ({ db }) => {
       const team = getTeamByName(db.db, name);
 
       if (!team) {

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -12,6 +12,11 @@ export interface DatabaseClient {
   runMigrations: () => void;
 }
 
+export interface ReadOnlyDatabaseClient {
+  db: SqlJsDatabase;
+  close: () => void;
+}
+
 // Embedded initial migration SQL
 const INITIAL_MIGRATION = `
 -- Hive Orchestrator Initial Schema
@@ -525,6 +530,58 @@ function runMigrations(db: SqlJsDatabase): void {
 export async function getDatabase(hiveDir: string): Promise<DatabaseClient> {
   const dbPath = join(hiveDir, 'hive.db');
   return createDatabase(dbPath);
+}
+
+export async function getReadOnlyDatabase(hiveDir: string): Promise<ReadOnlyDatabaseClient> {
+  const dbPath = join(hiveDir, 'hive.db');
+  const SqlJs = await getSqlJs();
+  if (!SqlJs) throw new InitializationError('Failed to initialize sql.js');
+
+  if (!existsSync(dbPath)) {
+    throw new InitializationError(`Database file not found: ${dbPath}`);
+  }
+
+  let db!: SqlJsDatabase;
+
+  for (let attempt = 1; attempt <= MAX_LOAD_RETRIES; attempt++) {
+    try {
+      const buffer = readFileSync(dbPath);
+      const fileSize = statSync(dbPath).size;
+
+      try {
+        db = new SqlJs.Database(buffer);
+        db.run('PRAGMA foreign_keys = ON');
+        db.exec('SELECT 1');
+      } catch (error) {
+        throw new DatabaseCorruptionError(
+          `Failed to load database file at ${dbPath}: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+
+      validateLoadedDatabase(db, fileSize);
+
+      try {
+        runMigrations(db);
+      } catch (error) {
+        throw new DatabaseCorruptionError(
+          `Database file at ${dbPath} appears corrupted (migrations failed): ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+
+      break;
+    } catch (error) {
+      if (error instanceof DatabaseCorruptionError && attempt < MAX_LOAD_RETRIES) {
+        await sleep(RETRY_DELAY_MS);
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  return {
+    db,
+    close: () => db.close(),
+  };
 }
 
 // Helper function to run a query and get results as objects

--- a/src/utils/with-hive-context.ts
+++ b/src/utils/with-hive-context.ts
@@ -2,7 +2,12 @@
 
 import chalk from 'chalk';
 import { join } from 'path';
-import { getDatabase, type DatabaseClient } from '../db/client.js';
+import {
+  getDatabase,
+  getReadOnlyDatabase,
+  type DatabaseClient,
+  type ReadOnlyDatabaseClient,
+} from '../db/client.js';
 import { acquireLock } from '../db/lock.js';
 import { findHiveRoot, getHivePaths, type HivePaths } from './paths.js';
 
@@ -10,6 +15,12 @@ export interface HiveContext {
   root: string;
   paths: HivePaths;
   db: DatabaseClient;
+}
+
+export interface ReadOnlyHiveContext {
+  root: string;
+  paths: HivePaths;
+  db: ReadOnlyDatabaseClient;
 }
 
 export interface HiveRootContext {
@@ -58,6 +69,19 @@ export async function withHiveContext<T>(fn: (ctx: HiveContext) => Promise<T> | 
     if (releaseLock) {
       await releaseLock();
     }
+  }
+}
+
+export async function withReadOnlyHiveContext<T>(
+  fn: (ctx: ReadOnlyHiveContext) => Promise<T> | T
+): Promise<T> {
+  const { root, paths } = resolveRoot();
+
+  const db = await getReadOnlyDatabase(paths.hiveDir);
+  try {
+    return await fn({ root, paths, db });
+  } finally {
+    db.close();
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds `withReadOnlyHiveContext()` function that loads the database without acquiring the exclusive file lock, eliminating contention for read-only operations
- Adds `ReadOnlyDatabaseClient` and `getReadOnlyDatabase()` in `src/db/client.ts` for lock-free DB snapshots
- Converts 13 read-only CLI subcommands across 8 files to use the new lock-free context: `status`, `stories list/show`, `agents list/logs/inspect`, `teams list/show`, `escalations list/show`, `pr queue/show`, `msg inbox/outbox`, and `my-stories` listing

[HIVE-OPT-001]

## Test plan
- [x] All 18 unit tests pass in `with-hive-context.test.ts` (7 new tests for `withReadOnlyHiveContext`)
- [x] New tests verify: no lock acquisition, callback result forwarding, DB cleanup on success/error, async support, workspace detection
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] No merge conflicts with main
- [x] CI checks passing (build + title check)
- [ ] Verify read-only commands work correctly in a live Hive workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)