### PR TITLE
feat: add --target-branch CLI option to hive req command

### DIFF
--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -48,6 +48,7 @@ CREATE TABLE IF NOT EXISTS requirements (
     submitted_by TEXT DEFAULT 'human',
     status TEXT DEFAULT 'pending' CHECK (status IN ('pending', 'planning', 'planned', 'in_progress', 'completed')),
     godmode BOOLEAN DEFAULT 0,
+    target_branch TEXT DEFAULT 'main',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -520,6 +521,24 @@ function runMigrations(db: SqlJsDatabase): void {
     );
     db.run("INSERT INTO migrations (name) VALUES ('009-add-pr-sync-indexes.sql')");
   }
+
+  // Migration 010: Add target_branch column to requirements table
+  const result010 = db.exec(
+    "SELECT name FROM migrations WHERE name = '010-add-target-branch.sql'"
+  );
+  const migration010Applied = result010.length > 0 && result010[0].values.length > 0;
+
+  if (!migration010Applied) {
+    const columns = db.exec('PRAGMA table_info(requirements)');
+    const hasTargetBranchColumn =
+      columns.length > 0 &&
+      columns[0].values.some((col: unknown[]) => col[1] === 'target_branch');
+
+    if (!hasTargetBranchColumn) {
+      db.run("ALTER TABLE requirements ADD COLUMN target_branch TEXT DEFAULT 'main'");
+    }
+    db.run("INSERT INTO migrations (name) VALUES ('010-add-target-branch.sql')");
+  }
 }
 
 export async function getDatabase(hiveDir: string): Promise<DatabaseClient> {
@@ -607,6 +626,7 @@ export interface RequirementRow {
   submitted_by: string;
   status: 'pending' | 'planning' | 'planned' | 'in_progress' | 'completed';
   godmode: number;
+  target_branch: string;
   created_at: string;
 }
 

--- a/src/db/queries/requirements.test.ts
+++ b/src/db/queries/requirements.test.ts
@@ -65,6 +65,26 @@ describe('requirements queries', () => {
       expect(req.godmode).toBe(0);
     });
 
+    it('should create a requirement with a custom target branch', () => {
+      const req = createRequirement(db, {
+        title: 'Feature with target branch',
+        description: 'Add feature targeting develop',
+        targetBranch: 'develop',
+      });
+
+      expect(req.id).toMatch(/^REQ-/);
+      expect(req.target_branch).toBe('develop');
+    });
+
+    it('should default target_branch to "main" when not specified', () => {
+      const req = createRequirement(db, {
+        title: 'Normal Feature',
+        description: 'Add feature without target branch',
+      });
+
+      expect(req.target_branch).toBe('main');
+    });
+
     it('should generate unique IDs', () => {
       const req1 = createRequirement(db, {
         title: 'Feature 1',
@@ -244,6 +264,21 @@ describe('requirements queries', () => {
       });
 
       expect(updated?.godmode).toBe(1);
+    });
+
+    it('should update requirement target_branch', () => {
+      const req = createRequirement(db, {
+        title: 'Title',
+        description: 'Description',
+      });
+
+      expect(req.target_branch).toBe('main');
+
+      const updated = updateRequirement(db, req.id, {
+        targetBranch: 'develop',
+      });
+
+      expect(updated?.target_branch).toBe('develop');
     });
 
     it('should update multiple fields at once', () => {

--- a/src/db/queries/requirements.ts
+++ b/src/db/queries/requirements.ts
@@ -13,6 +13,7 @@ export interface CreateRequirementInput {
   description: string;
   submittedBy?: string;
   godmode?: boolean;
+  targetBranch?: string;
 }
 
 export interface UpdateRequirementInput {
@@ -20,6 +21,7 @@ export interface UpdateRequirementInput {
   description?: string;
   status?: RequirementStatus;
   godmode?: boolean;
+  targetBranch?: string;
 }
 
 export function createRequirement(db: Database, input: CreateRequirementInput): RequirementRow {
@@ -29,10 +31,18 @@ export function createRequirement(db: Database, input: CreateRequirementInput): 
   run(
     db,
     `
-    INSERT INTO requirements (id, title, description, submitted_by, godmode, created_at)
-    VALUES (?, ?, ?, ?, ?, ?)
+    INSERT INTO requirements (id, title, description, submitted_by, godmode, target_branch, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
   `,
-    [id, input.title, input.description, input.submittedBy || 'human', input.godmode ? 1 : 0, now]
+    [
+      id,
+      input.title,
+      input.description,
+      input.submittedBy || 'human',
+      input.godmode ? 1 : 0,
+      input.targetBranch || 'main',
+      now,
+    ]
   );
 
   return getRequirementById(db, id)!;
@@ -91,6 +101,10 @@ export function updateRequirement(
   if (input.godmode !== undefined) {
     updates.push('godmode = ?');
     values.push(input.godmode ? 1 : 0);
+  }
+  if (input.targetBranch !== undefined) {
+    updates.push('target_branch = ?');
+    values.push(input.targetBranch);
   }
 
   if (updates.length === 0) {

--- a/src/db/queries/test-helpers.ts
+++ b/src/db/queries/test-helpers.ts
@@ -45,6 +45,7 @@ export async function createTestDatabase(): Promise<SqlJsDatabase> {
       submitted_by TEXT DEFAULT 'human',
       status TEXT DEFAULT 'pending' CHECK (status IN ('pending', 'planning', 'planned', 'in_progress', 'completed')),
       godmode BOOLEAN DEFAULT 0,
+      target_branch TEXT DEFAULT 'main',
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     );
 

--- a/src/orchestrator/scheduler.test.ts
+++ b/src/orchestrator/scheduler.test.ts
@@ -150,6 +150,7 @@ CREATE TABLE IF NOT EXISTS requirements (
     submitted_by TEXT DEFAULT 'human',
     status TEXT DEFAULT 'pending',
     godmode INTEGER DEFAULT 0,
+    target_branch TEXT DEFAULT 'main',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 `;


### PR DESCRIPTION
## Summary
- Adds `--target-branch <branch>` option to `hive req` command to control which branch PRs target
- When flag is not provided, shows an interactive prompt: select `main` (default) or enter a custom branch name
- Stores `target_branch` in the requirements table (new column with `DEFAULT 'main'`)
- Passes target branch info to the Tech Lead prompt so downstream agents know the target

## Story
STORY-TB001

## Changes
- **src/cli/commands/req.ts**: New `--target-branch` CLI option, interactive `promptTargetBranch()` using readline, `targetBranch` passed to `createRequirement()` and `generateTechLeadPrompt()`
- **src/db/client.ts**: Migration 010 adds `target_branch TEXT DEFAULT 'main'` column, updated initial schema and `RequirementRow` interface
- **src/db/queries/requirements.ts**: `targetBranch` field in `CreateRequirementInput`/`UpdateRequirementInput`, updated INSERT/UPDATE queries
- **src/db/queries/requirements.test.ts**: Tests for creating/updating requirements with target_branch
- **src/db/queries/test-helpers.ts**: Updated test schema with target_branch column
- **src/orchestrator/scheduler.test.ts**: Updated test schema with target_branch column

## Test plan
- [x] All 855 existing tests pass
- [x] New tests for `createRequirement` with custom target branch
- [x] New tests for `createRequirement` default target_branch
- [x] New test for `updateRequirement` target_branch
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] ESLint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)