### PR TITLE
feat: thread target_branch through agent prompts, QA agent, and scheduler

### DIFF
--- a/src/cli/commands/assign.ts
+++ b/src/cli/commands/assign.ts
@@ -117,6 +117,7 @@ export const assignCommand = new Command('assign')
           models: config.models,
           qa: config.qa,
           rootDir: root,
+          baseBranch: config.github.base_branch,
           saveFn: () => db.save(),
         });
 

--- a/src/cli/commands/manager.ts
+++ b/src/cli/commands/manager.ts
@@ -290,6 +290,7 @@ managerCommand
         models: config.models,
         qa: config.qa,
         rootDir: root,
+        baseBranch: config.github.base_branch,
         saveFn: () => db.save(),
       });
 
@@ -440,6 +441,7 @@ async function managerCheck(
         models: config.models,
         qa: config.qa,
         rootDir: root,
+        baseBranch: config.github.base_branch,
         saveFn: () => db.save(),
       }),
       hiveSessions: [],

--- a/src/cli/commands/pr.ts
+++ b/src/cli/commands/pr.ts
@@ -150,6 +150,7 @@ prCommand
               models: config.models,
               qa: config.qa,
               rootDir: root,
+              baseBranch: config.github.base_branch,
               saveFn: () => db.save(),
             });
             await scheduler.checkMergeQueue();
@@ -524,6 +525,7 @@ prCommand
               scaling: config.scaling,
               models: config.models,
               rootDir: root,
+              baseBranch: config.github.base_branch,
               saveFn: () => db.save(),
             });
             await scheduler.checkMergeQueue();

--- a/src/orchestrator/prompt-templates.test.ts
+++ b/src/orchestrator/prompt-templates.test.ts
@@ -167,6 +167,23 @@ describe('Prompt Templates', () => {
       expect(prompt).toContain('First Story');
       expect(prompt).toContain('Second Story');
     });
+
+    it('should default to main when no targetBranch is provided', () => {
+      const stories: StoryRow[] = [];
+      const prompt = generateSeniorPrompt(teamName, repoUrl, repoPath, stories);
+
+      expect(prompt).toContain('origin/main');
+      expect(prompt).toContain('--base main');
+    });
+
+    it('should use custom targetBranch in merge conflict and PR instructions', () => {
+      const stories: StoryRow[] = [];
+      const prompt = generateSeniorPrompt(teamName, repoUrl, repoPath, stories, 'develop');
+
+      expect(prompt).toContain('origin/develop');
+      expect(prompt).toContain('--base develop');
+      expect(prompt).not.toContain('origin/main');
+    });
   });
 
   describe('generateIntermediatePrompt', () => {
@@ -222,6 +239,20 @@ describe('Prompt Templates', () => {
       const prompt = generateIntermediatePrompt(teamName, repoUrl, repoPath, sessionName);
 
       expect(prompt).toContain('CI');
+    });
+
+    it('should use custom targetBranch in merge conflict and PR instructions', () => {
+      const prompt = generateIntermediatePrompt(
+        teamName,
+        repoUrl,
+        repoPath,
+        sessionName,
+        'release/v2'
+      );
+
+      expect(prompt).toContain('origin/release/v2');
+      expect(prompt).toContain('--base release/v2');
+      expect(prompt).not.toContain('origin/main');
     });
   });
 
@@ -279,6 +310,14 @@ describe('Prompt Templates', () => {
 
       expect(prompt).toContain('CI');
     });
+
+    it('should use custom targetBranch in merge conflict and PR instructions', () => {
+      const prompt = generateJuniorPrompt(teamName, repoUrl, repoPath, sessionName, 'staging');
+
+      expect(prompt).toContain('origin/staging');
+      expect(prompt).toContain('--base staging');
+      expect(prompt).not.toContain('origin/main');
+    });
   });
 
   describe('generateQAPrompt', () => {
@@ -329,6 +368,14 @@ describe('Prompt Templates', () => {
       expect(prompt).toContain('Code quality');
       expect(prompt).toContain('Functionality');
       expect(prompt).toContain('Story requirements');
+    });
+
+    it('should use custom targetBranch in review checklist', () => {
+      const prompt = generateQAPrompt(teamName, repoUrl, repoPath, sessionName, 'develop');
+
+      expect(prompt).toContain('origin/develop');
+      expect(prompt).toContain('Ensure the develop branch stays stable');
+      expect(prompt).not.toContain('origin/main');
     });
   });
 });

--- a/src/orchestrator/prompt-templates.ts
+++ b/src/orchestrator/prompt-templates.ts
@@ -9,7 +9,8 @@ export function generateSeniorPrompt(
   teamName: string,
   repoUrl: string,
   repoPath: string,
-  stories: StoryRow[]
+  stories: StoryRow[],
+  targetBranch: string = 'main'
 ): string {
   const storyList = stories
     .map(
@@ -59,13 +60,13 @@ hive pr submit -b feature/<story-id>-<description> -s <story-id> --from ${sessio
 
 ## Submitting PRs
 Before submitting your PR to the merge queue, always verify:
-1. **No merge conflicts** - Check with \`git fetch && git merge --no-commit origin/main\`
+1. **No merge conflicts** - Check with \`git fetch && git merge --no-commit origin/${targetBranch}\`
 2. **CI checks are passing** - Wait for GitHub Actions to complete and show green checkmarks
 3. **All tests pass locally** - Run \`npm test\` before submitting
 
 After verifying these checks, create and submit your PR:
 \`\`\`bash
-gh pr create --title "<type>: <description>" --body "..."
+gh pr create --base ${targetBranch} --title "<type>: <description>" --body "..."
 # IMPORTANT: PR titles MUST follow conventional commit format!
 # Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
 # Examples: "feat: add dependency checking to scheduler"
@@ -136,7 +137,8 @@ export function generateIntermediatePrompt(
   teamName: string,
   repoUrl: string,
   repoPath: string,
-  sessionName: string
+  sessionName: string,
+  targetBranch: string = 'main'
 ): string {
   const seniorSession = `hive-senior-${teamName.toLowerCase().replace(/[^a-z0-9]/g, '-')}`;
 
@@ -177,13 +179,13 @@ hive pr submit -b <branch-name> -s <story-id> --from ${sessionName}
 
 ## Submitting PRs
 Before submitting your PR to the merge queue, always verify:
-1. **No merge conflicts** - Check with \`git fetch && git merge --no-commit origin/main\`
+1. **No merge conflicts** - Check with \`git fetch && git merge --no-commit origin/${targetBranch}\`
 2. **CI checks are passing** - Wait for GitHub Actions to complete and show green checkmarks
 3. **All tests pass locally** - Run \`npm test\` before submitting
 
 After verifying these checks, create and submit your PR:
 \`\`\`bash
-gh pr create --title "<type>: <description>" --body "..."
+gh pr create --base ${targetBranch} --title "<type>: <description>" --body "..."
 # IMPORTANT: PR titles MUST follow conventional commit format!
 # Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
 # Examples: "feat: add dependency checking to scheduler"
@@ -250,7 +252,8 @@ export function generateJuniorPrompt(
   teamName: string,
   repoUrl: string,
   repoPath: string,
-  sessionName: string
+  sessionName: string,
+  targetBranch: string = 'main'
 ): string {
   const seniorSession = `hive-senior-${teamName.toLowerCase().replace(/[^a-z0-9]/g, '-')}`;
 
@@ -291,13 +294,13 @@ hive pr submit -b <branch-name> -s <story-id> --from ${sessionName}
 
 ## Submitting PRs
 Before submitting your PR to the merge queue, always verify:
-1. **No merge conflicts** - Check with \`git fetch && git merge --no-commit origin/main\`
+1. **No merge conflicts** - Check with \`git fetch && git merge --no-commit origin/${targetBranch}\`
 2. **CI checks are passing** - Wait for GitHub Actions to complete and show green checkmarks
 3. **All tests pass locally** - Run \`npm test\` before submitting
 
 After verifying these checks, create and submit your PR:
 \`\`\`bash
-gh pr create --title "<type>: <description>" --body "..."
+gh pr create --base ${targetBranch} --title "<type>: <description>" --body "..."
 # IMPORTANT: PR titles MUST follow conventional commit format!
 # Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
 # Examples: "feat: add dependency checking to scheduler"
@@ -364,7 +367,8 @@ export function generateQAPrompt(
   teamName: string,
   repoUrl: string,
   repoPath: string,
-  sessionName: string
+  sessionName: string,
+  targetBranch: string = 'main'
 ): string {
   return `You are a QA Engineer on Team ${teamName}.
 Your tmux session: ${sessionName}
@@ -419,7 +423,7 @@ hive msg send <developer-session> "Your PR was rejected: <reason>" --from ${sess
 
 ## Review Checklist
 For each PR, verify:
-1. **No merge conflicts** - Check with \`git fetch && git merge --no-commit origin/main\`
+1. **No merge conflicts** - Check with \`git fetch && git merge --no-commit origin/${targetBranch}\`
 2. **Tests pass** - Run the project's test suite
 3. **Code quality** - Check for code standards, no obvious bugs
 4. **Functionality** - Test that the changes work as expected
@@ -440,7 +444,7 @@ hive msg outbox ${sessionName}
 - Review PRs in queue order (first in, first out)
 - Be thorough but efficient
 - Provide clear feedback when rejecting
-- Ensure main branch stays stable
+- Ensure the ${targetBranch} branch stays stable
 
 Start by running \`hive pr queue\` to see PRs waiting for review.`;
 }


### PR DESCRIPTION
## Story: STORY-TB002

Thread the `target_branch` from requirements through the entire agent pipeline so PRs are created against the correct branch.

### Changes

**Prompt templates** (`src/orchestrator/prompt-templates.ts`):
- Added `targetBranch` parameter (default `'main'`) to all 4 prompt functions
- Replaced all hardcoded `origin/main` references with `origin/<targetBranch>`
- Updated `gh pr create` instructions to use `--base <targetBranch>`

**QA Agent** (`src/agents/qa.ts`):
- Added `targetBranch` to `QAContext` interface
- Added `resolveTargetBranch()` that checks requirement-level override, falls back to context default
- `createPR()` now uses resolved target branch instead of hardcoded `'main'`

**Scheduler** (`src/orchestrator/scheduler.ts`):
- Added `baseBranch` to `SchedulerConfig` (populated from `config.github.base_branch`)
- Added `resolveTeamTargetBranch()` that checks active requirements for team-specific overrides
- All prompt generation calls now pass the resolved target branch

**CLI commands** (`assign.ts`, `manager.ts`, `pr.ts`):
- All `new Scheduler()` calls now pass `baseBranch: config.github.base_branch`

### Tests
- 9 new tests covering target branch threading across all prompt types and scheduler resolution
- All 892 existing tests continue to pass

### Config fallback chain
`requirement.target_branch` → `config.github.base_branch` → `'main'`