### PR TITLE
feat: thread target_branch through agent prompts, QA agent, and branch creation

### DIFF
--- a/src/cli/commands/assign.ts
+++ b/src/cli/commands/assign.ts
@@ -116,6 +116,7 @@ export const assignCommand = new Command('assign')
           scaling: config.scaling,
           models: config.models,
           qa: config.qa,
+          github: config.github,
           rootDir: root,
           saveFn: () => db.save(),
         });

--- a/src/cli/commands/manager.ts
+++ b/src/cli/commands/manager.ts
@@ -289,6 +289,7 @@ managerCommand
         scaling: config.scaling,
         models: config.models,
         qa: config.qa,
+        github: config.github,
         rootDir: root,
         saveFn: () => db.save(),
       });
@@ -439,6 +440,7 @@ async function managerCheck(
         scaling: config.scaling,
         models: config.models,
         qa: config.qa,
+        github: config.github,
         rootDir: root,
         saveFn: () => db.save(),
       }),

--- a/src/cli/commands/pr.ts
+++ b/src/cli/commands/pr.ts
@@ -149,6 +149,7 @@ prCommand
               scaling: config.scaling,
               models: config.models,
               qa: config.qa,
+              github: config.github,
               rootDir: root,
               saveFn: () => db.save(),
             });
@@ -523,6 +524,7 @@ prCommand
             const scheduler = new Scheduler(db.db, {
               scaling: config.scaling,
               models: config.models,
+              github: config.github,
               rootDir: root,
               saveFn: () => db.save(),
             });

--- a/src/orchestrator/prompt-templates.test.ts
+++ b/src/orchestrator/prompt-templates.test.ts
@@ -125,6 +125,23 @@ describe('Prompt Templates', () => {
       expect(prompt).toContain('CI');
     });
 
+    it('should default to main when no target branch specified', () => {
+      const stories: StoryRow[] = [];
+      const prompt = generateSeniorPrompt(teamName, repoUrl, repoPath, stories);
+
+      expect(prompt).toContain('origin/main');
+      expect(prompt).toContain('--base main');
+    });
+
+    it('should use custom target branch in merge conflict check and PR creation', () => {
+      const stories: StoryRow[] = [];
+      const prompt = generateSeniorPrompt(teamName, repoUrl, repoPath, stories, 'develop');
+
+      expect(prompt).toContain('origin/develop');
+      expect(prompt).toContain('--base develop');
+      expect(prompt).not.toContain('origin/main');
+    });
+
     it('should include multiple stories', () => {
       const stories: StoryRow[] = [
         {
@@ -223,6 +240,27 @@ describe('Prompt Templates', () => {
 
       expect(prompt).toContain('CI');
     });
+
+    it('should default to main when no target branch specified', () => {
+      const prompt = generateIntermediatePrompt(teamName, repoUrl, repoPath, sessionName);
+
+      expect(prompt).toContain('origin/main');
+      expect(prompt).toContain('--base main');
+    });
+
+    it('should use custom target branch in merge conflict check and PR creation', () => {
+      const prompt = generateIntermediatePrompt(
+        teamName,
+        repoUrl,
+        repoPath,
+        sessionName,
+        'release/v2'
+      );
+
+      expect(prompt).toContain('origin/release/v2');
+      expect(prompt).toContain('--base release/v2');
+      expect(prompt).not.toContain('origin/main');
+    });
   });
 
   describe('generateJuniorPrompt', () => {
@@ -279,6 +317,27 @@ describe('Prompt Templates', () => {
 
       expect(prompt).toContain('CI');
     });
+
+    it('should default to main when no target branch specified', () => {
+      const prompt = generateJuniorPrompt(teamName, repoUrl, repoPath, sessionName);
+
+      expect(prompt).toContain('origin/main');
+      expect(prompt).toContain('--base main');
+    });
+
+    it('should use custom target branch in merge conflict check and PR creation', () => {
+      const prompt = generateJuniorPrompt(
+        teamName,
+        repoUrl,
+        repoPath,
+        sessionName,
+        'feature/epic-1'
+      );
+
+      expect(prompt).toContain('origin/feature/epic-1');
+      expect(prompt).toContain('--base feature/epic-1');
+      expect(prompt).not.toContain('origin/main');
+    });
   });
 
   describe('generateQAPrompt', () => {
@@ -329,6 +388,22 @@ describe('Prompt Templates', () => {
       expect(prompt).toContain('Code quality');
       expect(prompt).toContain('Functionality');
       expect(prompt).toContain('Story requirements');
+    });
+
+    it('should default to main when no target branch specified', () => {
+      const prompt = generateQAPrompt(teamName, repoUrl, repoPath, sessionName);
+
+      expect(prompt).toContain('origin/main');
+      expect(prompt).toContain('Ensure main branch stays stable');
+    });
+
+    it('should use custom target branch in review checklist and guidelines', () => {
+      const prompt = generateQAPrompt(teamName, repoUrl, repoPath, sessionName, 'develop');
+
+      expect(prompt).toContain('origin/develop');
+      expect(prompt).toContain('Ensure develop branch stays stable');
+      expect(prompt).not.toContain('origin/main');
+      expect(prompt).not.toContain('Ensure main branch stays stable');
     });
   });
 });

--- a/src/orchestrator/prompt-templates.ts
+++ b/src/orchestrator/prompt-templates.ts
@@ -9,7 +9,8 @@ export function generateSeniorPrompt(
   teamName: string,
   repoUrl: string,
   repoPath: string,
-  stories: StoryRow[]
+  stories: StoryRow[],
+  targetBranch: string = 'main'
 ): string {
   const storyList = stories
     .map(
@@ -59,13 +60,13 @@ hive pr submit -b feature/<story-id>-<description> -s <story-id> --from ${sessio
 
 ## Submitting PRs
 Before submitting your PR to the merge queue, always verify:
-1. **No merge conflicts** - Check with \`git fetch && git merge --no-commit origin/main\`
+1. **No merge conflicts** - Check with \`git fetch && git merge --no-commit origin/${targetBranch}\`
 2. **CI checks are passing** - Wait for GitHub Actions to complete and show green checkmarks
 3. **All tests pass locally** - Run \`npm test\` before submitting
 
 After verifying these checks, create and submit your PR:
 \`\`\`bash
-gh pr create --title "<type>: <description>" --body "..."
+gh pr create --base ${targetBranch} --title "<type>: <description>" --body "..."
 # IMPORTANT: PR titles MUST follow conventional commit format!
 # Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
 # Examples: "feat: add dependency checking to scheduler"
@@ -136,7 +137,8 @@ export function generateIntermediatePrompt(
   teamName: string,
   repoUrl: string,
   repoPath: string,
-  sessionName: string
+  sessionName: string,
+  targetBranch: string = 'main'
 ): string {
   const seniorSession = `hive-senior-${teamName.toLowerCase().replace(/[^a-z0-9]/g, '-')}`;
 
@@ -177,13 +179,13 @@ hive pr submit -b <branch-name> -s <story-id> --from ${sessionName}
 
 ## Submitting PRs
 Before submitting your PR to the merge queue, always verify:
-1. **No merge conflicts** - Check with \`git fetch && git merge --no-commit origin/main\`
+1. **No merge conflicts** - Check with \`git fetch && git merge --no-commit origin/${targetBranch}\`
 2. **CI checks are passing** - Wait for GitHub Actions to complete and show green checkmarks
 3. **All tests pass locally** - Run \`npm test\` before submitting
 
 After verifying these checks, create and submit your PR:
 \`\`\`bash
-gh pr create --title "<type>: <description>" --body "..."
+gh pr create --base ${targetBranch} --title "<type>: <description>" --body "..."
 # IMPORTANT: PR titles MUST follow conventional commit format!
 # Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
 # Examples: "feat: add dependency checking to scheduler"
@@ -250,7 +252,8 @@ export function generateJuniorPrompt(
   teamName: string,
   repoUrl: string,
   repoPath: string,
-  sessionName: string
+  sessionName: string,
+  targetBranch: string = 'main'
 ): string {
   const seniorSession = `hive-senior-${teamName.toLowerCase().replace(/[^a-z0-9]/g, '-')}`;
 
@@ -291,13 +294,13 @@ hive pr submit -b <branch-name> -s <story-id> --from ${sessionName}
 
 ## Submitting PRs
 Before submitting your PR to the merge queue, always verify:
-1. **No merge conflicts** - Check with \`git fetch && git merge --no-commit origin/main\`
+1. **No merge conflicts** - Check with \`git fetch && git merge --no-commit origin/${targetBranch}\`
 2. **CI checks are passing** - Wait for GitHub Actions to complete and show green checkmarks
 3. **All tests pass locally** - Run \`npm test\` before submitting
 
 After verifying these checks, create and submit your PR:
 \`\`\`bash
-gh pr create --title "<type>: <description>" --body "..."
+gh pr create --base ${targetBranch} --title "<type>: <description>" --body "..."
 # IMPORTANT: PR titles MUST follow conventional commit format!
 # Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
 # Examples: "feat: add dependency checking to scheduler"
@@ -364,7 +367,8 @@ export function generateQAPrompt(
   teamName: string,
   repoUrl: string,
   repoPath: string,
-  sessionName: string
+  sessionName: string,
+  targetBranch: string = 'main'
 ): string {
   return `You are a QA Engineer on Team ${teamName}.
 Your tmux session: ${sessionName}
@@ -419,7 +423,7 @@ hive msg send <developer-session> "Your PR was rejected: <reason>" --from ${sess
 
 ## Review Checklist
 For each PR, verify:
-1. **No merge conflicts** - Check with \`git fetch && git merge --no-commit origin/main\`
+1. **No merge conflicts** - Check with \`git fetch && git merge --no-commit origin/${targetBranch}\`
 2. **Tests pass** - Run the project's test suite
 3. **Code quality** - Check for code standards, no obvious bugs
 4. **Functionality** - Test that the changes work as expected
@@ -440,7 +444,7 @@ hive msg outbox ${sessionName}
 - Review PRs in queue order (first in, first out)
 - Be thorough but efficient
 - Provide clear feedback when rejecting
-- Ensure main branch stays stable
+- Ensure ${targetBranch} branch stays stable
 
 Start by running \`hive pr queue\` to see PRs waiting for review.`;
 }


### PR DESCRIPTION
## Summary
- Threads the `target_branch` field (added by STORY-TB001) through the entire agent pipeline so PRs are created against the correct branch
- Adds `targetBranch` parameter to all 4 prompt template functions with hardcoded `origin/main` replaced by the configured target branch
- Updates QA agent `createPR()` to resolve target branch per-story from the requirement, with config-level and default fallbacks
- Adds `resolveTargetBranch()` to Scheduler that looks up active requirements for a team
- Updates all Scheduler constructor call sites to pass `github` config

## Story
STORY-TB002: Thread target_branch through agent prompts, QA agent, and branch creation

## Changes
- `src/orchestrator/prompt-templates.ts` — Added `targetBranch` param to all 4 prompt functions; replaced `origin/main` and `--base main` with configured branch
- `src/agents/qa.ts` — Added `targetBranch` to `QAContext.qaConfig`; updated `createPR()` to look up requirement target_branch per-story
- `src/orchestrator/scheduler.ts` — Added `GitHubConfig` to `SchedulerConfig`; added `resolveTargetBranch()` method; updated `spawnAgent()` to pass target branch
- `src/cli/commands/assign.ts`, `manager.ts`, `pr.ts` — Pass `github` config to Scheduler constructors
- Tests: 12 new tests covering target branch in prompts and scheduler resolution

## Test plan
- [x] All 897 existing tests pass
- [x] TypeScript type-check passes
- [x] ESLint passes
- [x] Build succeeds
- [x] New tests verify target branch appears in all prompt types
- [x] New tests verify `resolveTargetBranch()` with various requirement configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)