### PR TITLE
fix: prevent rogue agents from persisting after story merge

### DIFF
--- a/src/cli/commands/manager.ts
+++ b/src/cli/commands/manager.ts
@@ -1195,6 +1195,48 @@ async function spinDownMergedAgents(ctx: ManagerCheckContext): Promise<void> {
     agentsSpunDown++;
   }
 
+  // Also find working agents with no current story that have no active stories assigned
+  const orphanedWorkingAgents = queryAll<{
+    id: string;
+    tmux_session: string | null;
+    type: string;
+  }>(
+    ctx.db.db,
+    `SELECT id, tmux_session, type FROM agents
+     WHERE status = 'working' AND current_story_id IS NULL AND type != 'tech_lead'`
+  );
+
+  for (const agent of orphanedWorkingAgents) {
+    // Check if this agent has any active (non-merged) stories assigned
+    const activeStories = queryAll<StoryRow>(
+      ctx.db.db,
+      `SELECT * FROM stories WHERE assigned_agent_id = ? AND status NOT IN ('merged', 'draft')`,
+      [agent.id]
+    );
+    if (activeStories.length > 0) continue;
+
+    const agentSession = ctx.hiveSessions.find(
+      s => s.name === agent.tmux_session || s.name.includes(agent.id)
+    );
+
+    if (agentSession) {
+      await sendToTmuxSession(agentSession.name, `# No active stories assigned. Spinning down...`);
+      await new Promise(resolve => setTimeout(resolve, AGENT_SPINDOWN_DELAY_MS));
+      await killTmuxSession(agentSession.name);
+    }
+
+    await withTransaction(ctx.db.db, () => {
+      updateAgent(ctx.db.db, agent.id, { status: 'terminated', currentStoryId: null });
+      createLog(ctx.db.db, {
+        agentId: agent.id,
+        eventType: 'AGENT_TERMINATED',
+        message: `Agent spun down: status was working with no current story and no active stories`,
+      });
+    });
+
+    agentsSpunDown++;
+  }
+
   if (agentsSpunDown > 0) {
     ctx.db.save();
     console.log(chalk.green(`  Spun down ${agentsSpunDown} agent(s) after successful merge`));

--- a/src/orchestrator/scheduler.ts
+++ b/src/orchestrator/scheduler.ts
@@ -382,8 +382,11 @@ export class Scheduler {
       if (!team) continue;
 
       // Get available agents for this team
+      // Include agents that are working but have no current story (effectively idle)
       const agents = getAgentsByTeam(this.db, teamId).filter(
-        a => a.status === 'idle' && a.type !== 'qa'
+        a =>
+          a.type !== 'qa' &&
+          (a.status === 'idle' || (a.status === 'working' && a.current_story_id === null))
       );
 
       // Find or create a Senior for delegation
@@ -997,7 +1000,7 @@ export class Scheduler {
 
     updateAgent(this.db, agent.id, {
       tmuxSession: sessionName,
-      status: 'working',
+      status: 'idle',
       worktreePath,
     });
 


### PR DESCRIPTION
## Summary
- Clear agent's `currentStoryId` and set status to `idle` when a story is merged in `auto-merge.ts`, preventing agents from being stuck in `working` state with no assigned work
- Change `spawnAgent` to set initial agent status to `idle` instead of `working`, so agents only become `working` when explicitly assigned a story
- Expand the agent availability filter in `assignStories()` to also consider agents that are `working` but have `NULL` `currentStoryId` (effectively idle)
- Add cleanup sweep in `spinDownMergedAgents` to find and terminate working agents with no current story and no active stories assigned
- Added 4 new tests covering the agent cleanup and reassignment behavior

Fixes: FIX-001

## Test plan
- [x] All 856 tests pass (852 existing + 4 new)
- [x] Prettier formatting verified
- [ ] Verify merged stories properly clear agent state in integration testing
- [ ] Verify orphaned working agents are terminated in manager daemon cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)