### PR TITLE
feat: add autonomy level enforcement to auto-merge

### DIFF
--- a/src/utils/auto-merge.test.ts
+++ b/src/utils/auto-merge.test.ts
@@ -1,7 +1,7 @@
 // Licensed under the Hungry Ghost Hive License. See LICENSE.
 
 import type { Database } from 'sql.js';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createAgent, getAgentById, updateAgent } from '../db/queries/agents.js';
 import {
   createPullRequest,
@@ -11,6 +11,19 @@ import {
 import { createStory, getStoryById, updateStory } from '../db/queries/stories.js';
 import { createTeam } from '../db/queries/teams.js';
 import { createTestDatabase } from '../db/queries/test-helpers.js';
+
+vi.mock('../config/loader.js', () => ({
+  loadConfig: vi.fn(),
+}));
+
+vi.mock('./paths.js', () => ({
+  getHivePaths: vi.fn(() => ({ hiveDir: '/mock/hive' })),
+}));
+
+import { loadConfig } from '../config/loader.js';
+import { autoMergeApprovedPRs } from './auto-merge.js';
+
+const mockLoadConfig = vi.mocked(loadConfig);
 
 describe('auto-merge functionality', () => {
   let db: Database;
@@ -178,6 +191,78 @@ describe('auto-merge functionality', () => {
       const agentAfter = getAgentById(db, agent.id);
       expect(agentAfter?.current_story_id).toBe(story2.id);
       expect(agentAfter?.status).toBe('working');
+    });
+  });
+
+  describe('autonomy level enforcement', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should skip auto-merge when autonomy level is partial', async () => {
+      // Setup: Create an approved PR
+      const pr = createPullRequest(db, {
+        storyId,
+        teamId,
+        branchName: 'feature/test',
+        githubPrNumber: 123,
+      });
+      updatePullRequest(db, pr.id, { status: 'approved' });
+
+      // Mock config with partial autonomy
+      mockLoadConfig.mockReturnValue({
+        integrations: {
+          autonomy: {
+            level: 'partial',
+          },
+          source_control: { provider: 'github' },
+          project_management: { provider: 'none' },
+        },
+      } as any);
+
+      // Create a minimal database client wrapper
+      const dbClient = {
+        db,
+        save: vi.fn(),
+        close: vi.fn(),
+        runMigrations: vi.fn(),
+      };
+
+      const result = await autoMergeApprovedPRs('/mock/root', dbClient);
+
+      // Should return 0 (no PRs merged) in partial mode
+      expect(result).toBe(0);
+      // loadConfig should have been called
+      expect(mockLoadConfig).toHaveBeenCalledWith('/mock/hive');
+    });
+
+    it('should not skip auto-merge when autonomy level is full', async () => {
+      // Mock config with full autonomy
+      mockLoadConfig.mockReturnValue({
+        integrations: {
+          autonomy: {
+            level: 'full',
+          },
+          source_control: { provider: 'github' },
+          project_management: { provider: 'none' },
+        },
+      } as any);
+
+      // Create a minimal database client wrapper (no approved PRs)
+      const dbClient = {
+        db,
+        save: vi.fn(),
+        close: vi.fn(),
+        runMigrations: vi.fn(),
+      };
+
+      // With full autonomy and no approved PRs, should return 0 (not skip due to autonomy)
+      const result = await autoMergeApprovedPRs('/mock/root', dbClient);
+
+      // Should return 0 because there are no approved PRs, not because of autonomy level
+      expect(result).toBe(0);
+      // loadConfig should have been called
+      expect(mockLoadConfig).toHaveBeenCalledWith('/mock/hive');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Modified `src/utils/auto-merge.ts` to check `integrations.autonomy.level` configuration
- In partial autonomy mode, auto-merge is skipped entirely (returns 0)
- Added unit tests for both 'partial' and 'full' autonomy levels

## Changes
- Import `loadConfig` from `../config/loader.js`
- Import `getHivePaths` from `./paths.js`
- Load config at the start of `autoMergeApprovedPRs`
- Check `config.integrations.autonomy.level === 'partial'` and return early if true
- Added two new test cases in `auto-merge.test.ts`:
  - Test that auto-merge is skipped when autonomy level is 'partial'
  - Test that auto-merge proceeds when autonomy level is 'full'

## Test Plan
- [x] All existing tests pass
- [x] New unit tests pass
- [x] Linting and type checking pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)