### PR TITLE
fix: auto-open browser for Jira OAuth flows

### DIFF
--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -6,6 +6,7 @@ import { getEnvFilePath } from '../../auth/env-store.js';
 import { runGitHubDeviceFlow } from '../../auth/github-oauth.js';
 import { startJiraOAuthFlow, storeJiraTokens } from '../../auth/jira-oauth.js';
 import { TokenStore } from '../../auth/token-store.js';
+import { openBrowser } from '../../utils/browser.js';
 import { withHiveRoot } from '../../utils/with-hive-context.js';
 
 export const authCommand = new Command('auth').description('Manage OAuth authentication');
@@ -75,6 +76,7 @@ authCommand
       const result = await startJiraOAuthFlow({
         clientId,
         clientSecret,
+        openBrowser,
       });
 
       // Store tokens using TokenStore

--- a/src/cli/wizard/init-wizard.ts
+++ b/src/cli/wizard/init-wizard.ts
@@ -6,6 +6,7 @@ import { join } from 'path';
 import { startJiraOAuthFlow, storeJiraTokens } from '../../auth/jira-oauth.js';
 import { TokenStore } from '../../auth/token-store.js';
 import type { IntegrationsConfig } from '../../config/schema.js';
+import { openBrowser } from '../../utils/browser.js';
 import { getHivePaths } from '../../utils/paths.js';
 import { runJiraSetup } from './jira-setup.js';
 
@@ -162,6 +163,7 @@ async function buildResult(
       const oauthResult = await startJiraOAuthFlow({
         clientId,
         clientSecret,
+        openBrowser,
       });
 
       // Store tokens in .env

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -1,0 +1,27 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import { execa } from 'execa';
+
+/**
+ * Open a URL in the default browser.
+ * Works on macOS, Windows, and Linux.
+ */
+export async function openBrowser(url: string): Promise<void> {
+  const platform = process.platform;
+
+  try {
+    if (platform === 'darwin') {
+      // macOS
+      await execa('open', [url]);
+    } else if (platform === 'win32') {
+      // Windows
+      await execa('cmd', ['/c', 'start', url]);
+    } else {
+      // Linux and other platforms
+      await execa('xdg-open', [url]);
+    }
+  } catch (err) {
+    // If opening the browser fails, silently continue
+    // The user will still see the URL printed to the terminal
+  }
+}


### PR DESCRIPTION
## Summary
- Add browser auto-opening functionality for Jira OAuth flows in both init-wizard and auth commands
- Implement cross-platform browser opening utility supporting macOS, Windows, and Linux
- Pass openBrowser parameter to startJiraOAuthFlow() in init-wizard.ts and auth.ts

## Test plan
- ✅ All tests pass (1070 tests)
- Manual testing needed: Verify browser opens automatically when OAuth flow is initiated
- Graceful fallback: If browser can't open, URL is still printed to terminal

Fixes [FIX-002]

🤖 Generated with [Claude Code](https://claude.com/claude-code)