### PR TITLE
fix: use fixed port 9876 for Jira OAuth callback URL

### DIFF
--- a/src/auth/jira-oauth.ts
+++ b/src/auth/jira-oauth.ts
@@ -201,7 +201,7 @@ function generateState(): string {
  * Returns the OAuth result with tokens and cloud metadata.
  */
 export async function startJiraOAuthFlow(options: JiraOAuthOptions): Promise<JiraOAuthResult> {
-  const { clientId, clientSecret, port = 0, openBrowser, timeoutMs = 300_000 } = options;
+  const { clientId, clientSecret, port = 9876, openBrowser, timeoutMs = 300_000 } = options;
   const state = generateState();
 
   return new Promise<JiraOAuthResult>((resolve, reject) => {

--- a/src/cli/wizard/init-wizard.ts
+++ b/src/cli/wizard/init-wizard.ts
@@ -136,7 +136,7 @@ async function buildResult(
     );
     console.log(chalk.gray('  1. Go to https://developer.atlassian.com/console/myapps/'));
     console.log(chalk.gray('  2. Create a new app with OAuth 2.0 (3LO)'));
-    console.log(chalk.gray('  3. Add callback URL: http://127.0.0.1:PORT/callback'));
+    console.log(chalk.gray('  3. Add callback URL: http://127.0.0.1:9876/callback'));
     console.log(chalk.gray('  4. Enable scopes: read:jira-work, write:jira-work, offline_access'));
     console.log();
 


### PR DESCRIPTION
## Summary
- Default OAuth callback port changed from `0` (random) to `9876` (fixed)
- Updated init wizard instructions to show the correct callback URL: `http://127.0.0.1:9876/callback`
- Users can now register this exact URL in the Atlassian Developer Console

## Test plan
- [x] All 15 Jira OAuth tests pass
- [x] Build succeeds
- [ ] Register `http://127.0.0.1:9876/callback` in Atlassian app and run `hive init`

🤖 Generated with [Claude Code](https://claude.com/claude-code)