### PR TITLE
fix: use localhost for OAuth callback and add Jira board scopes

### DIFF
--- a/src/auth/jira-oauth.ts
+++ b/src/auth/jira-oauth.ts
@@ -8,6 +8,9 @@ const JIRA_OAUTH_SCOPES = [
   'read:jira-work',
   'write:jira-work',
   'read:jira-user',
+  'manage:jira-configuration',
+  'read:board-scope:jira-software',
+  'write:board-scope:jira-software',
   'offline_access',
   'read:confluence-content.all',
 ] as const;
@@ -238,9 +241,9 @@ export async function startJiraOAuthFlow(options: JiraOAuthOptions): Promise<Jir
       });
     });
 
-    server.listen(port, '127.0.0.1', () => {
+    server.listen(port, 'localhost', () => {
       const addr = server!.address() as { port: number };
-      const redirectUri = `http://127.0.0.1:${addr.port}/callback`;
+      const redirectUri = `http://localhost:${addr.port}/callback`;
       const authUrl = buildAuthorizationUrl(clientId, redirectUri, state);
 
       // Open browser for authorization
@@ -273,7 +276,7 @@ async function handleCallback(
     settle: (err: Error | null, result?: JiraOAuthResult) => void;
   }
 ): Promise<void> {
-  const url = new URL(req.url ?? '/', `http://127.0.0.1:${ctx.serverPort}`);
+  const url = new URL(req.url ?? '/', `http://localhost:${ctx.serverPort}`);
 
   if (url.pathname !== '/callback') {
     res.writeHead(404, { 'Content-Type': 'text/plain' });
@@ -303,7 +306,7 @@ async function handleCallback(
   }
 
   try {
-    const redirectUri = `http://127.0.0.1:${ctx.serverPort}/callback`;
+    const redirectUri = `http://localhost:${ctx.serverPort}/callback`;
     const tokens = await exchangeCodeForTokens(code, ctx.clientId, ctx.clientSecret, redirectUri);
     const resources = await fetchAccessibleResources(tokens.access_token);
 

--- a/src/cli/wizard/init-wizard.ts
+++ b/src/cli/wizard/init-wizard.ts
@@ -136,7 +136,7 @@ async function buildResult(
     );
     console.log(chalk.gray('  1. Go to https://developer.atlassian.com/console/myapps/'));
     console.log(chalk.gray('  2. Create a new app with OAuth 2.0 (3LO)'));
-    console.log(chalk.gray('  3. Add callback URL: http://127.0.0.1:9876/callback'));
+    console.log(chalk.gray('  3. Add callback URL: http://localhost:9876/callback'));
     console.log(chalk.gray('  4. Enable scopes: read:jira-work, write:jira-work, offline_access'));
     console.log();
 


### PR DESCRIPTION
## Summary
- Changed OAuth callback URL from `http://127.0.0.1` to `http://localhost` (Atlassian rejects 127.0.0.1)
- Added missing OAuth scopes for Jira board creation: `manage:jira-configuration`, `read:board-scope:jira-software`, `write:board-scope:jira-software`
- Fixed init wizard instructions to show correct callback URL

## Test plan
- [x] All 15 Jira OAuth tests pass
- [x] Build succeeds
- [ ] Re-run `hive init` with Jira, re-authorize (new scopes require re-consent), create board

🤖 Generated with [Claude Code](https://claude.com/claude-code)