### PR TITLE
fix: revert callback URL to 127.0.0.1, keep board scopes

### DIFF
--- a/src/auth/jira-oauth.ts
+++ b/src/auth/jira-oauth.ts
@@ -241,9 +241,9 @@ export async function startJiraOAuthFlow(options: JiraOAuthOptions): Promise<Jir
       });
     });
 
-    server.listen(port, 'localhost', () => {
+    server.listen(port, '127.0.0.1', () => {
       const addr = server!.address() as { port: number };
-      const redirectUri = `http://localhost:${addr.port}/callback`;
+      const redirectUri = `http://127.0.0.1:${addr.port}/callback`;
       const authUrl = buildAuthorizationUrl(clientId, redirectUri, state);
 
       // Open browser for authorization
@@ -276,7 +276,7 @@ async function handleCallback(
     settle: (err: Error | null, result?: JiraOAuthResult) => void;
   }
 ): Promise<void> {
-  const url = new URL(req.url ?? '/', `http://localhost:${ctx.serverPort}`);
+  const url = new URL(req.url ?? '/', `http://127.0.0.1:${ctx.serverPort}`);
 
   if (url.pathname !== '/callback') {
     res.writeHead(404, { 'Content-Type': 'text/plain' });
@@ -306,7 +306,7 @@ async function handleCallback(
   }
 
   try {
-    const redirectUri = `http://localhost:${ctx.serverPort}/callback`;
+    const redirectUri = `http://127.0.0.1:${ctx.serverPort}/callback`;
     const tokens = await exchangeCodeForTokens(code, ctx.clientId, ctx.clientSecret, redirectUri);
     const resources = await fetchAccessibleResources(tokens.access_token);
 

--- a/src/cli/wizard/init-wizard.ts
+++ b/src/cli/wizard/init-wizard.ts
@@ -136,7 +136,7 @@ async function buildResult(
     );
     console.log(chalk.gray('  1. Go to https://developer.atlassian.com/console/myapps/'));
     console.log(chalk.gray('  2. Create a new app with OAuth 2.0 (3LO)'));
-    console.log(chalk.gray('  3. Add callback URL: http://localhost:9876/callback'));
+    console.log(chalk.gray('  3. Add callback URL: http://127.0.0.1:9876/callback'));
     console.log(chalk.gray('  4. Enable scopes: read:jira-work, write:jira-work, offline_access'));
     console.log();
 


### PR DESCRIPTION
## Summary
- Reverts callback URL from `localhost` back to `127.0.0.1` (localhost broke the flow)
- Retains the board creation scopes added in #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)