### PR TITLE
fix: remove invalid Jira board-scope OAuth scopes

### DIFF
--- a/src/auth/jira-oauth.ts
+++ b/src/auth/jira-oauth.ts
@@ -9,8 +9,6 @@ const JIRA_OAUTH_SCOPES = [
   'write:jira-work',
   'read:jira-user',
   'manage:jira-configuration',
-  'read:board-scope:jira-software',
-  'write:board-scope:jira-software',
   'offline_access',
   'read:confluence-content.all',
 ] as const;


### PR DESCRIPTION
## Summary
- Removed `read:board-scope:jira-software` and `write:board-scope:jira-software` — these are Forge scopes, not valid for OAuth 2.0 (3LO), and caused Atlassian to reject the auth request entirely
- `manage:jira-configuration` (valid classic scope) is retained for board creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)