### PR TITLE
fix: add correct Jira Software board OAuth scopes

### DIFF
--- a/src/auth/jira-oauth.ts
+++ b/src/auth/jira-oauth.ts
@@ -9,6 +9,8 @@ const JIRA_OAUTH_SCOPES = [
   'write:jira-work',
   'read:jira-user',
   'manage:jira-configuration',
+  'read:board-scope:jira-software',
+  'write:board-scope.admin:jira-software',
   'offline_access',
   'read:confluence-content.all',
 ] as const;


### PR DESCRIPTION
## Summary
- Added `read:board-scope:jira-software` and `write:board-scope.admin:jira-software` OAuth scopes
- These are the correct Jira Software scopes needed for board creation via the Agile API

🤖 Generated with [Claude Code](https://claude.com/claude-code)