### PR TITLE
feat: add connector interfaces and provider registry

### DIFF
--- a/src/integrations/connectors/index.ts
+++ b/src/integrations/connectors/index.ts
@@ -1,0 +1,4 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+export * from './types.js';
+export * from './registry.js';

--- a/src/integrations/connectors/registry.test.ts
+++ b/src/integrations/connectors/registry.test.ts
@@ -1,0 +1,160 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { ConnectorRegistry } from './registry.js';
+import type {
+  ConnectorInfo,
+  ProjectManagementConnector,
+  SourceControlConnector,
+} from './types.js';
+
+function makePMInfo(name: string): ConnectorInfo {
+  return { name, displayName: name.toUpperCase(), available: true };
+}
+
+function makeSCInfo(name: string): ConnectorInfo {
+  return { name, displayName: name.toUpperCase(), available: true };
+}
+
+// Minimal stub implementing the PM connector interface for testing
+function stubPMConnector(name: string): ProjectManagementConnector {
+  return {
+    info: makePMInfo(name),
+    authenticate: async () => {},
+    isAuthenticated: async () => true,
+    fetchEpic: async () => ({ key: '', id: '', title: '', description: '' }),
+    createEpic: async () => ({ ref: { provider: name, externalId: '', externalKey: '' } }),
+    createIssue: async () => ({ ref: { provider: name, externalId: '', externalKey: '' } }),
+    createSubtask: async () => ({ ref: { provider: name, externalId: '', externalKey: '' } }),
+    transitionIssue: async () => true,
+    postComment: async () => true,
+    syncRequirement: async () => ({ epicRef: null, stories: [], errors: [] }),
+    getSetupWizard: () => ({ run: async () => ({}) }),
+    getInstructions: () => '',
+  };
+}
+
+function stubSCConnector(name: string): SourceControlConnector {
+  return {
+    info: makeSCInfo(name),
+    authenticate: async () => {},
+    isAuthenticated: async () => true,
+    createPullRequest: async () => ({ number: 1, url: '' }),
+    getPullRequest: async () => ({
+      number: 1,
+      url: '',
+      title: '',
+      state: 'open' as const,
+      headBranch: '',
+      baseBranch: '',
+      additions: 0,
+      deletions: 0,
+      changedFiles: 0,
+    }),
+    mergePullRequest: async () => {},
+    listPullRequests: async () => [],
+  };
+}
+
+describe('ConnectorRegistry', () => {
+  afterEach(() => {
+    ConnectorRegistry._reset();
+  });
+
+  describe('PM connectors', () => {
+    it('should register and retrieve a PM connector', () => {
+      const info = makePMInfo('jira');
+      ConnectorRegistry.registerPMConnector(info, () => stubPMConnector('jira'));
+
+      const connector = ConnectorRegistry.getPMConnector('jira', {});
+      expect(connector.info.name).toBe('jira');
+    });
+
+    it('should throw for unregistered PM provider', () => {
+      expect(() => ConnectorRegistry.getPMConnector('linear', {})).toThrow(
+        /Unknown project management provider: "linear"/
+      );
+    });
+
+    it('should list registered PM providers', () => {
+      ConnectorRegistry.registerPMConnector(makePMInfo('jira'), () => stubPMConnector('jira'));
+      ConnectorRegistry.registerPMConnector(makePMInfo('linear'), () => stubPMConnector('linear'));
+
+      const names = ConnectorRegistry.getPMProviderNames();
+      expect(names).toContain('jira');
+      expect(names).toContain('linear');
+    });
+
+    it('should return PM provider info', () => {
+      ConnectorRegistry.registerPMConnector(
+        { name: 'linear', displayName: 'Linear', available: false, comingSoon: true },
+        () => stubPMConnector('linear')
+      );
+
+      const providers = ConnectorRegistry.getPMProviders();
+      expect(providers).toHaveLength(1);
+      expect(providers[0].name).toBe('linear');
+      expect(providers[0].available).toBe(false);
+      expect(providers[0].comingSoon).toBe(true);
+    });
+
+    it('should check if PM connector exists', () => {
+      expect(ConnectorRegistry.hasPMConnector('jira')).toBe(false);
+      ConnectorRegistry.registerPMConnector(makePMInfo('jira'), () => stubPMConnector('jira'));
+      expect(ConnectorRegistry.hasPMConnector('jira')).toBe(true);
+    });
+
+    it('should pass config to PM factory', () => {
+      const info = makePMInfo('jira');
+      let receivedConfig: Record<string, unknown> = {};
+      ConnectorRegistry.registerPMConnector(info, config => {
+        receivedConfig = config;
+        return stubPMConnector('jira');
+      });
+
+      ConnectorRegistry.getPMConnector('jira', { project_key: 'HIVE' });
+      expect(receivedConfig).toEqual({ project_key: 'HIVE' });
+    });
+  });
+
+  describe('SC connectors', () => {
+    it('should register and retrieve a SC connector', () => {
+      const info = makeSCInfo('github');
+      ConnectorRegistry.registerSCConnector(info, () => stubSCConnector('github'));
+
+      const connector = ConnectorRegistry.getSCConnector('github', {});
+      expect(connector.info.name).toBe('github');
+    });
+
+    it('should throw for unregistered SC provider', () => {
+      expect(() => ConnectorRegistry.getSCConnector('gitlab', {})).toThrow(
+        /Unknown source control provider: "gitlab"/
+      );
+    });
+
+    it('should list registered SC providers', () => {
+      ConnectorRegistry.registerSCConnector(makeSCInfo('github'), () => stubSCConnector('github'));
+
+      const names = ConnectorRegistry.getSCProviderNames();
+      expect(names).toEqual(['github']);
+    });
+
+    it('should check if SC connector exists', () => {
+      expect(ConnectorRegistry.hasSCConnector('github')).toBe(false);
+      ConnectorRegistry.registerSCConnector(makeSCInfo('github'), () => stubSCConnector('github'));
+      expect(ConnectorRegistry.hasSCConnector('github')).toBe(true);
+    });
+  });
+
+  describe('_reset', () => {
+    it('should clear all registrations', () => {
+      ConnectorRegistry.registerPMConnector(makePMInfo('jira'), () => stubPMConnector('jira'));
+      ConnectorRegistry.registerSCConnector(makeSCInfo('github'), () => stubSCConnector('github'));
+
+      ConnectorRegistry._reset();
+
+      expect(ConnectorRegistry.getPMProviderNames()).toHaveLength(0);
+      expect(ConnectorRegistry.getSCProviderNames()).toHaveLength(0);
+    });
+  });
+});

--- a/src/integrations/connectors/registry.ts
+++ b/src/integrations/connectors/registry.ts
@@ -1,0 +1,147 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import type {
+  ConnectorInfo,
+  ProjectManagementConnector,
+  SourceControlConnector,
+} from './types.js';
+
+/**
+ * Factory function that creates a connector instance given provider-specific config.
+ */
+export type ConnectorFactory<T> = (config: Record<string, unknown>) => T;
+
+/**
+ * Registration entry for a connector provider.
+ */
+interface ConnectorEntry<T> {
+  info: ConnectorInfo;
+  factory: ConnectorFactory<T>;
+}
+
+/**
+ * Central registry for source control and project management connectors.
+ *
+ * Connectors register themselves with the registry at startup.
+ * Orchestration code looks up connectors by provider name.
+ *
+ * Usage:
+ *   ConnectorRegistry.registerPMConnector({ ... }, factory);
+ *   const connector = ConnectorRegistry.getPMConnector('jira', config);
+ */
+export class ConnectorRegistry {
+  private static pmConnectors = new Map<string, ConnectorEntry<ProjectManagementConnector>>();
+  private static scConnectors = new Map<string, ConnectorEntry<SourceControlConnector>>();
+
+  // ─── Project Management ──────────────────────────────────────────────
+
+  /**
+   * Register a project management connector provider.
+   */
+  static registerPMConnector(
+    info: ConnectorInfo,
+    factory: ConnectorFactory<ProjectManagementConnector>
+  ): void {
+    ConnectorRegistry.pmConnectors.set(info.name, { info, factory });
+  }
+
+  /**
+   * Create a project management connector instance for the given provider.
+   * @throws Error if the provider is not registered.
+   */
+  static getPMConnector(
+    providerName: string,
+    config: Record<string, unknown>
+  ): ProjectManagementConnector {
+    const entry = ConnectorRegistry.pmConnectors.get(providerName);
+    if (!entry) {
+      throw new Error(
+        `Unknown project management provider: "${providerName}". ` +
+          `Registered providers: [${ConnectorRegistry.getPMProviderNames().join(', ')}]`
+      );
+    }
+    return entry.factory(config);
+  }
+
+  /**
+   * Get metadata for all registered PM providers.
+   */
+  static getPMProviders(): ConnectorInfo[] {
+    return Array.from(ConnectorRegistry.pmConnectors.values()).map(e => e.info);
+  }
+
+  /**
+   * Get names of all registered PM providers.
+   */
+  static getPMProviderNames(): string[] {
+    return Array.from(ConnectorRegistry.pmConnectors.keys());
+  }
+
+  /**
+   * Check if a PM provider is registered.
+   */
+  static hasPMConnector(providerName: string): boolean {
+    return ConnectorRegistry.pmConnectors.has(providerName);
+  }
+
+  // ─── Source Control ──────────────────────────────────────────────────
+
+  /**
+   * Register a source control connector provider.
+   */
+  static registerSCConnector(
+    info: ConnectorInfo,
+    factory: ConnectorFactory<SourceControlConnector>
+  ): void {
+    ConnectorRegistry.scConnectors.set(info.name, { info, factory });
+  }
+
+  /**
+   * Create a source control connector instance for the given provider.
+   * @throws Error if the provider is not registered.
+   */
+  static getSCConnector(
+    providerName: string,
+    config: Record<string, unknown>
+  ): SourceControlConnector {
+    const entry = ConnectorRegistry.scConnectors.get(providerName);
+    if (!entry) {
+      throw new Error(
+        `Unknown source control provider: "${providerName}". ` +
+          `Registered providers: [${ConnectorRegistry.getSCProviderNames().join(', ')}]`
+      );
+    }
+    return entry.factory(config);
+  }
+
+  /**
+   * Get metadata for all registered SC providers.
+   */
+  static getSCProviders(): ConnectorInfo[] {
+    return Array.from(ConnectorRegistry.scConnectors.values()).map(e => e.info);
+  }
+
+  /**
+   * Get names of all registered SC providers.
+   */
+  static getSCProviderNames(): string[] {
+    return Array.from(ConnectorRegistry.scConnectors.keys());
+  }
+
+  /**
+   * Check if a SC provider is registered.
+   */
+  static hasSCConnector(providerName: string): boolean {
+    return ConnectorRegistry.scConnectors.has(providerName);
+  }
+
+  // ─── Test Utilities ──────────────────────────────────────────────────
+
+  /**
+   * Clear all registered connectors. For testing only.
+   */
+  static _reset(): void {
+    ConnectorRegistry.pmConnectors.clear();
+    ConnectorRegistry.scConnectors.clear();
+  }
+}

--- a/src/integrations/connectors/types.ts
+++ b/src/integrations/connectors/types.ts
@@ -1,0 +1,242 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+/**
+ * External reference linking a local entity to a provider resource.
+ */
+export interface ExternalRef {
+  /** Provider name (e.g., 'jira', 'github', 'linear') */
+  provider: string;
+  /** Provider-specific unique ID */
+  externalId: string;
+  /** Provider-specific key (e.g., Jira issue key 'HIVE-42') */
+  externalKey: string;
+  /** URL to view the resource in the provider's UI */
+  externalUrl?: string;
+}
+
+/**
+ * Metadata describing a connector for registry and UI purposes.
+ */
+export interface ConnectorInfo {
+  /** Machine-readable provider name (e.g., 'jira', 'github') */
+  name: string;
+  /** Human-readable display name */
+  displayName: string;
+  /** Whether the connector is ready for use (false = coming soon) */
+  available: boolean;
+  /** Show as "coming soon" in wizard UI */
+  comingSoon?: boolean;
+}
+
+/**
+ * Setup wizard provided by a connector for interactive configuration.
+ */
+export interface SetupWizard {
+  /** Run the interactive setup flow, returning provider-specific config */
+  run(): Promise<Record<string, unknown>>;
+}
+
+/**
+ * Result of creating an issue or epic in a project management tool.
+ */
+export interface PMCreateResult {
+  ref: ExternalRef;
+}
+
+/**
+ * Fetched epic/parent data from a project management tool.
+ */
+export interface PMFetchedEpic {
+  key: string;
+  id: string;
+  title: string;
+  description: string;
+  /** Provider-specific raw data */
+  raw?: unknown;
+}
+
+/**
+ * Options for creating an epic in a project management tool.
+ */
+export interface PMCreateEpicOptions {
+  title: string;
+  description: string;
+  projectKey: string;
+  labels?: string[];
+}
+
+/**
+ * Options for creating an issue in a project management tool.
+ */
+export interface PMCreateIssueOptions {
+  title: string;
+  description: string;
+  projectKey: string;
+  issueType?: string;
+  parentKey?: string;
+  storyPoints?: number;
+  labels?: string[];
+  /** Provider-specific additional fields */
+  extra?: Record<string, unknown>;
+}
+
+/**
+ * Options for creating a subtask under a parent issue.
+ */
+export interface PMCreateSubtaskOptions {
+  parentKey: string;
+  projectKey: string;
+  title: string;
+  description?: string;
+  labels?: string[];
+}
+
+/**
+ * Options for transitioning an issue to a new status.
+ */
+export interface PMTransitionOptions {
+  issueKeyOrId: string;
+  targetStatus: string;
+  statusMapping?: Record<string, string>;
+}
+
+/**
+ * Options for posting a comment to an issue.
+ */
+export interface PMCommentOptions {
+  issueKeyOrId: string;
+  body: string;
+  /** Optional structured event type for lifecycle tracking */
+  event?: string;
+  /** Additional context (agent name, PR URL, etc.) */
+  context?: Record<string, string>;
+}
+
+/**
+ * Options for syncing a requirement and its stories to the PM tool.
+ */
+export interface PMSyncRequirementOptions {
+  requirementId: string;
+  storyIds: string[];
+  teamName?: string;
+}
+
+/**
+ * Result of syncing a requirement to the PM tool.
+ */
+export interface PMSyncResult {
+  epicRef: ExternalRef | null;
+  stories: Array<{
+    storyId: string;
+    ref: ExternalRef;
+  }>;
+  errors: string[];
+}
+
+/**
+ * Interface that all project management connectors must implement.
+ *
+ * Wraps provider-specific operations (Jira, Linear, Asana, etc.)
+ * behind a common interface so orchestration code can be provider-agnostic.
+ */
+export interface ProjectManagementConnector {
+  /** Connector metadata */
+  readonly info: ConnectorInfo;
+
+  /** Authenticate with the provider (e.g., run OAuth flow) */
+  authenticate(): Promise<void>;
+
+  /** Check whether valid credentials exist */
+  isAuthenticated(): Promise<boolean>;
+
+  /** Fetch an epic/parent issue by key or URL */
+  fetchEpic(keyOrUrl: string): Promise<PMFetchedEpic>;
+
+  /** Create a new epic */
+  createEpic(options: PMCreateEpicOptions): Promise<PMCreateResult>;
+
+  /** Create a new issue */
+  createIssue(options: PMCreateIssueOptions): Promise<PMCreateResult>;
+
+  /** Create a subtask under a parent issue */
+  createSubtask(options: PMCreateSubtaskOptions): Promise<PMCreateResult>;
+
+  /** Transition an issue to a new status */
+  transitionIssue(options: PMTransitionOptions): Promise<boolean>;
+
+  /** Post a comment on an issue */
+  postComment(options: PMCommentOptions): Promise<boolean>;
+
+  /** Sync a requirement and its stories to the PM tool */
+  syncRequirement(options: PMSyncRequirementOptions): Promise<PMSyncResult>;
+
+  /** Get the setup wizard for interactive configuration */
+  getSetupWizard(): SetupWizard;
+
+  /** Get provider-specific instructions for agents */
+  getInstructions(): string;
+}
+
+/**
+ * Options for creating a pull request via a source control connector.
+ */
+export interface SCCreatePROptions {
+  title: string;
+  body: string;
+  baseBranch: string;
+  headBranch: string;
+  draft?: boolean;
+  labels?: string[];
+  assignees?: string[];
+}
+
+/**
+ * Pull request information returned by source control connectors.
+ */
+export interface SCPullRequestInfo {
+  number: number;
+  url: string;
+  title: string;
+  state: 'open' | 'closed' | 'merged';
+  headBranch: string;
+  baseBranch: string;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+}
+
+/**
+ * Interface that all source control connectors must implement.
+ *
+ * Wraps provider-specific operations (GitHub, GitLab, Bitbucket, etc.)
+ * behind a common interface.
+ */
+export interface SourceControlConnector {
+  /** Connector metadata */
+  readonly info: ConnectorInfo;
+
+  /** Authenticate with the provider */
+  authenticate(): Promise<void>;
+
+  /** Check whether valid credentials exist */
+  isAuthenticated(): Promise<boolean>;
+
+  /** Create a pull request */
+  createPullRequest(workDir: string, options: SCCreatePROptions): Promise<{ number: number; url: string }>;
+
+  /** Get pull request details by number */
+  getPullRequest(workDir: string, prNumber: number): Promise<SCPullRequestInfo>;
+
+  /** Merge a pull request */
+  mergePullRequest(
+    workDir: string,
+    prNumber: number,
+    options?: { method?: 'merge' | 'squash' | 'rebase'; deleteAfterMerge?: boolean }
+  ): Promise<void>;
+
+  /** List pull requests */
+  listPullRequests(
+    workDir: string,
+    state?: 'open' | 'closed' | 'all'
+  ): Promise<SCPullRequestInfo[]>;
+}


### PR DESCRIPTION
## Summary
- Define `SourceControlConnector` and `ProjectManagementConnector` interfaces with `ExternalRef` type for provider-agnostic integration abstraction
- Create `ConnectorRegistry` class for dynamic registration and lookup of SC/PM connector providers
- Update `ProjectManagementConfigSchema` to accept extensible provider strings (beyond `none`/`jira`) with `provider_config` for third-party provider configuration

[STORY-CONN-001]

## Test plan
- [x] All 11 new registry tests pass (register, lookup, list, error on unknown provider, config passthrough, reset)
- [x] All 32 existing schema tests pass — backward compatibility preserved
- [x] Full test suite: 1153 tests pass across 66 files
- [x] Lint: 0 errors (only pre-existing warnings in other files)
- [x] Type-check: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)