### PR TITLE
feat: define generic connector interfaces for PM and SCM

### DIFF
--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -1,0 +1,33 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+/**
+ * Generic connector interfaces and types for project management and SCM integrations.
+ *
+ * @module connectors
+ */
+
+export type { ProjectManagementConnector, SCMConnector } from './interfaces.js';
+
+export type {
+  CreateEpicInput,
+  CreateIssueResult,
+  CreatePRInput,
+  CreatePRResult,
+  CreateStoryInput,
+  CreateSubtaskInput,
+  DependencyLinkType,
+  ExternalComment,
+  ExternalEpic,
+  ExternalIssue,
+  ExternalIssueType,
+  ExternalPRReview,
+  ExternalPriority,
+  ExternalPullRequest,
+  ExternalSprint,
+  ExternalStatus,
+  ExternalTransition,
+  ExternalUser,
+  LifecycleCommentContext,
+  LifecycleEvent,
+  MergePROptions,
+} from './types.js';

--- a/src/connectors/interfaces.test.ts
+++ b/src/connectors/interfaces.test.ts
@@ -1,0 +1,424 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import { describe, expect, it } from 'vitest';
+import type { ProjectManagementConnector, SCMConnector } from './interfaces.js';
+import type {
+  CreateEpicInput,
+  CreateIssueResult,
+  CreatePRInput,
+  CreatePRResult,
+  CreateStoryInput,
+  CreateSubtaskInput,
+  ExternalEpic,
+  ExternalIssue,
+  ExternalPRReview,
+  ExternalPullRequest,
+  ExternalSprint,
+  ExternalTransition,
+  LifecycleCommentContext,
+  LifecycleEvent,
+  MergePROptions,
+} from './types.js';
+
+// ── Mock PM Connector ───────────────────────────────────────────────────────
+
+class MockPMConnector implements ProjectManagementConnector {
+  readonly type = 'mock-pm';
+  readonly displayName = 'Mock PM';
+
+  async authenticate(): Promise<boolean> {
+    return true;
+  }
+
+  recognizesUrl(url: string): boolean {
+    return url.includes('mock-pm.example.com');
+  }
+
+  async fetchEpic(urlOrKey: string): Promise<ExternalEpic> {
+    return {
+      id: '1',
+      key: 'MOCK-1',
+      title: `Epic for ${urlOrKey}`,
+      description: 'Test epic',
+      status: { id: '1', name: 'To Do', category: 'todo' },
+      labels: ['test'],
+      project: { id: '1', key: 'MOCK', name: 'Mock Project' },
+    };
+  }
+
+  async createEpic(_input: CreateEpicInput): Promise<CreateIssueResult> {
+    return { id: '1', key: 'MOCK-1', url: 'https://mock-pm.example.com/MOCK-1' };
+  }
+
+  async createStory(_input: CreateStoryInput): Promise<CreateIssueResult> {
+    return { id: '2', key: 'MOCK-2' };
+  }
+
+  async createSubtask(_input: CreateSubtaskInput): Promise<CreateIssueResult | null> {
+    return { id: '3', key: 'MOCK-3' };
+  }
+
+  async fetchIssue(issueKey: string): Promise<ExternalIssue> {
+    return {
+      id: '1',
+      key: issueKey,
+      summary: 'Test Issue',
+      description: 'A test issue',
+      status: { id: '1', name: 'To Do', category: 'todo' },
+      issueType: { id: '1', name: 'Story', subtask: false },
+      labels: [],
+      project: { id: '1', key: 'MOCK', name: 'Mock Project' },
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
+  }
+
+  async postComment(
+    _issueKey: string,
+    _event: LifecycleEvent,
+    _context?: LifecycleCommentContext
+  ): Promise<boolean> {
+    return true;
+  }
+
+  async postProgress(_subtaskKey: string, _message: string, _agentName?: string): Promise<boolean> {
+    return true;
+  }
+
+  async transitionStatus(_issueKey: string, _targetStatus: string): Promise<boolean> {
+    return true;
+  }
+
+  async getTransitions(_issueKey: string): Promise<ExternalTransition[]> {
+    return [
+      {
+        id: '1',
+        name: 'Start Progress',
+        to: { id: '2', name: 'In Progress', category: 'in_progress' },
+      },
+    ];
+  }
+
+  async linkDependency(_fromKey: string, _toKey: string): Promise<void> {}
+
+  async moveToSprint(_issueKeys: string[], _sprintId: string): Promise<void> {}
+
+  async getActiveSprint(): Promise<ExternalSprint | null> {
+    return {
+      id: '1',
+      name: 'Sprint 1',
+      state: 'active',
+      startDate: '2026-01-01T00:00:00Z',
+      endDate: '2026-01-14T00:00:00Z',
+    };
+  }
+}
+
+// ── Mock SCM Connector ──────────────────────────────────────────────────────
+
+class MockSCMConnector implements SCMConnector {
+  readonly type = 'mock-scm';
+  readonly displayName = 'Mock SCM';
+
+  async isAuthenticated(): Promise<boolean> {
+    return true;
+  }
+
+  async createPR(_workDir: string, _input: CreatePRInput): Promise<CreatePRResult> {
+    return { number: 1, url: 'https://mock-scm.example.com/pr/1' };
+  }
+
+  async fetchPR(_workDir: string, prNumber: number): Promise<ExternalPullRequest> {
+    return {
+      id: '1',
+      number: prNumber,
+      url: `https://mock-scm.example.com/pr/${prNumber}`,
+      title: 'Test PR',
+      state: 'open',
+      headBranch: 'feature/test',
+      baseBranch: 'main',
+      additions: 10,
+      deletions: 5,
+      changedFiles: 2,
+    };
+  }
+
+  async listPRs(
+    _workDir: string,
+    _state?: 'open' | 'closed' | 'all'
+  ): Promise<ExternalPullRequest[]> {
+    return [];
+  }
+
+  async mergePR(_workDir: string, _prNumber: number, _options?: MergePROptions): Promise<void> {}
+
+  async closePR(_workDir: string, _prNumber: number): Promise<void> {}
+
+  async addReviewer(_workDir: string, _prNumber: number, _reviewer: string): Promise<void> {}
+
+  async getReviews(_workDir: string, _prNumber: number): Promise<ExternalPRReview[]> {
+    return [{ author: 'reviewer', state: 'approved', body: 'LGTM' }];
+  }
+
+  async commentOnPR(_workDir: string, _prNumber: number, _body: string): Promise<void> {}
+
+  async getPRDiff(_workDir: string, _prNumber: number): Promise<string> {
+    return '+ added line\n- removed line';
+  }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('ProjectManagementConnector', () => {
+  const connector: ProjectManagementConnector = new MockPMConnector();
+
+  it('should expose type and displayName', () => {
+    expect(connector.type).toBe('mock-pm');
+    expect(connector.displayName).toBe('Mock PM');
+  });
+
+  it('should authenticate', async () => {
+    expect(await connector.authenticate()).toBe(true);
+  });
+
+  it('should recognize matching URLs', () => {
+    expect(connector.recognizesUrl('https://mock-pm.example.com/browse/MOCK-1')).toBe(true);
+    expect(connector.recognizesUrl('https://other.example.com/issue/1')).toBe(false);
+  });
+
+  it('should fetch an epic', async () => {
+    const epic = await connector.fetchEpic('MOCK-1');
+    expect(epic.key).toBe('MOCK-1');
+    expect(epic.title).toContain('Epic for');
+    expect(epic.status.category).toBe('todo');
+    expect(epic.project.key).toBe('MOCK');
+  });
+
+  it('should create an epic', async () => {
+    const result = await connector.createEpic({ title: 'New Epic', description: 'Desc' });
+    expect(result.id).toBe('1');
+    expect(result.key).toBe('MOCK-1');
+    expect(result.url).toBeDefined();
+  });
+
+  it('should create a story', async () => {
+    const result = await connector.createStory({
+      title: 'New Story',
+      description: 'Story desc',
+      epicKey: 'MOCK-1',
+      storyPoints: 5,
+      labels: ['feature'],
+    });
+    expect(result.id).toBe('2');
+    expect(result.key).toBe('MOCK-2');
+  });
+
+  it('should create a subtask', async () => {
+    const result = await connector.createSubtask({
+      parentIssueKey: 'MOCK-2',
+      agentName: 'hive-senior-1',
+      storyTitle: 'Test Story',
+      approachSteps: ['Step 1', 'Step 2'],
+    });
+    expect(result).not.toBeNull();
+    expect(result!.key).toBe('MOCK-3');
+  });
+
+  it('should fetch an issue', async () => {
+    const issue = await connector.fetchIssue('MOCK-2');
+    expect(issue.key).toBe('MOCK-2');
+    expect(issue.summary).toBe('Test Issue');
+    expect(issue.issueType.subtask).toBe(false);
+  });
+
+  it('should post a lifecycle comment', async () => {
+    const result = await connector.postComment('MOCK-2', 'work_started', {
+      agentName: 'hive-senior-1',
+      branchName: 'feature/test',
+    });
+    expect(result).toBe(true);
+  });
+
+  it('should post progress to subtask', async () => {
+    const result = await connector.postProgress('MOCK-3', 'Making progress', 'hive-senior-1');
+    expect(result).toBe(true);
+  });
+
+  it('should transition issue status', async () => {
+    const result = await connector.transitionStatus('MOCK-2', 'In Progress');
+    expect(result).toBe(true);
+  });
+
+  it('should get available transitions', async () => {
+    const transitions = await connector.getTransitions('MOCK-2');
+    expect(transitions).toHaveLength(1);
+    expect(transitions[0].to.name).toBe('In Progress');
+    expect(transitions[0].to.category).toBe('in_progress');
+  });
+
+  it('should link dependencies', async () => {
+    await expect(connector.linkDependency('MOCK-1', 'MOCK-2', 'blocks')).resolves.toBeUndefined();
+  });
+
+  it('should move issues to sprint', async () => {
+    await expect(connector.moveToSprint(['MOCK-2'], '1')).resolves.toBeUndefined();
+  });
+
+  it('should get active sprint', async () => {
+    const sprint = await connector.getActiveSprint();
+    expect(sprint).not.toBeNull();
+    expect(sprint!.state).toBe('active');
+    expect(sprint!.name).toBe('Sprint 1');
+  });
+});
+
+describe('SCMConnector', () => {
+  const connector: SCMConnector = new MockSCMConnector();
+
+  it('should expose type and displayName', () => {
+    expect(connector.type).toBe('mock-scm');
+    expect(connector.displayName).toBe('Mock SCM');
+  });
+
+  it('should check authentication', async () => {
+    expect(await connector.isAuthenticated()).toBe(true);
+  });
+
+  it('should create a PR', async () => {
+    const result = await connector.createPR('/tmp/repo', {
+      title: 'feat: new feature',
+      body: 'Description',
+      baseBranch: 'main',
+      headBranch: 'feature/test',
+    });
+    expect(result.number).toBe(1);
+    expect(result.url).toContain('pr/1');
+  });
+
+  it('should fetch a PR', async () => {
+    const pr = await connector.fetchPR('/tmp/repo', 42);
+    expect(pr.number).toBe(42);
+    expect(pr.state).toBe('open');
+    expect(pr.headBranch).toBe('feature/test');
+    expect(pr.baseBranch).toBe('main');
+  });
+
+  it('should list PRs', async () => {
+    const prs = await connector.listPRs('/tmp/repo', 'open');
+    expect(Array.isArray(prs)).toBe(true);
+  });
+
+  it('should merge a PR', async () => {
+    await expect(
+      connector.mergePR('/tmp/repo', 1, { method: 'squash', deleteBranch: true })
+    ).resolves.toBeUndefined();
+  });
+
+  it('should close a PR', async () => {
+    await expect(connector.closePR('/tmp/repo', 1)).resolves.toBeUndefined();
+  });
+
+  it('should add a reviewer', async () => {
+    await expect(connector.addReviewer('/tmp/repo', 1, 'reviewer')).resolves.toBeUndefined();
+  });
+
+  it('should get reviews', async () => {
+    const reviews = await connector.getReviews('/tmp/repo', 1);
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0].state).toBe('approved');
+  });
+
+  it('should comment on a PR', async () => {
+    await expect(connector.commentOnPR('/tmp/repo', 1, 'Great work!')).resolves.toBeUndefined();
+  });
+
+  it('should get PR diff', async () => {
+    const diff = await connector.getPRDiff('/tmp/repo', 1);
+    expect(diff).toContain('added line');
+  });
+});
+
+describe('ExternalIssue type compatibility', () => {
+  it('should support optional fields', () => {
+    const minimal: ExternalIssue = {
+      id: '1',
+      key: 'TEST-1',
+      summary: 'Minimal issue',
+      description: '',
+      status: { id: '1', name: 'Open', category: 'todo' },
+      issueType: { id: '1', name: 'Story', subtask: false },
+      labels: [],
+      project: { id: '1', key: 'TEST', name: 'Test' },
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
+    expect(minimal.priority).toBeUndefined();
+    expect(minimal.assignee).toBeUndefined();
+    expect(minimal.storyPoints).toBeUndefined();
+    expect(minimal.parentKey).toBeUndefined();
+    expect(minimal.url).toBeUndefined();
+    expect(minimal.raw).toBeUndefined();
+  });
+
+  it('should support all optional fields populated', () => {
+    const full: ExternalIssue = {
+      id: '1',
+      key: 'TEST-1',
+      summary: 'Full issue',
+      description: 'Detailed description',
+      status: { id: '2', name: 'In Progress', category: 'in_progress' },
+      issueType: { id: '2', name: 'Subtask', subtask: true },
+      priority: { id: '1', name: 'High' },
+      assignee: { id: 'u1', displayName: 'Dev', email: 'dev@test.com' },
+      reporter: { id: 'u2', displayName: 'PM' },
+      labels: ['hive-managed'],
+      storyPoints: 8,
+      parentKey: 'TEST-0',
+      project: { id: '1', key: 'TEST', name: 'Test' },
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-02T00:00:00Z',
+      url: 'https://pm.example.com/TEST-1',
+      raw: { provider_specific: true },
+    };
+    expect(full.storyPoints).toBe(8);
+    expect(full.assignee?.email).toBe('dev@test.com');
+    expect(full.raw).toBeDefined();
+  });
+});
+
+describe('ExternalPullRequest type compatibility', () => {
+  it('should support minimal PR', () => {
+    const pr: ExternalPullRequest = {
+      id: '1',
+      number: 42,
+      url: 'https://scm.example.com/pr/42',
+      title: 'feat: something',
+      state: 'open',
+      headBranch: 'feature/x',
+      baseBranch: 'main',
+      additions: 0,
+      deletions: 0,
+      changedFiles: 0,
+    };
+    expect(pr.draft).toBeUndefined();
+    expect(pr.reviewers).toBeUndefined();
+  });
+});
+
+describe('LifecycleEvent types', () => {
+  it('should cover all expected events', () => {
+    const events: LifecycleEvent[] = [
+      'assigned',
+      'work_started',
+      'progress',
+      'approach_posted',
+      'pr_created',
+      'qa_started',
+      'qa_passed',
+      'qa_failed',
+      'merged',
+      'blocked',
+    ];
+    expect(events).toHaveLength(10);
+  });
+});

--- a/src/connectors/interfaces.ts
+++ b/src/connectors/interfaces.ts
@@ -1,0 +1,269 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+/**
+ * Generic connector interfaces for project management (PM) and
+ * source code management (SCM) integrations.
+ *
+ * These interfaces decouple the Hive orchestrator from specific providers
+ * like Jira or GitHub, allowing new integrations (Monday, GitLab, Linear, etc.)
+ * to be added by implementing the same contract.
+ */
+
+import type {
+  CreateEpicInput,
+  CreateIssueResult,
+  CreatePRInput,
+  CreatePRResult,
+  CreateStoryInput,
+  CreateSubtaskInput,
+  DependencyLinkType,
+  ExternalEpic,
+  ExternalIssue,
+  ExternalPRReview,
+  ExternalPullRequest,
+  ExternalSprint,
+  ExternalTransition,
+  LifecycleCommentContext,
+  LifecycleEvent,
+  MergePROptions,
+} from './types.js';
+
+// ── Project Management Connector ────────────────────────────────────────────
+
+/**
+ * Interface for project management tool integrations (Jira, Monday, Linear, etc.).
+ *
+ * Implementations wrap a specific provider's API and translate between
+ * the provider's native data model and Hive's generic types.
+ */
+export interface ProjectManagementConnector {
+  /** Unique identifier for this connector type (e.g., "jira", "monday") */
+  readonly type: string;
+
+  /** Human-readable provider name (e.g., "Jira", "Monday.com") */
+  readonly displayName: string;
+
+  /**
+   * Authenticate with the PM provider.
+   * Implementations should handle OAuth flows, token refresh, etc.
+   * @returns true if authentication succeeded
+   */
+  authenticate(): Promise<boolean>;
+
+  /**
+   * Check whether a URL belongs to this PM provider.
+   * Used for URL-based epic import to determine which connector should handle it.
+   * @param url - URL to check
+   * @returns true if this connector recognizes the URL
+   */
+  recognizesUrl(url: string): boolean;
+
+  // ── Epic Operations ─────────────────────────────────────────────────────
+
+  /**
+   * Fetch an epic from the PM tool by its URL or key.
+   * Used during requirement import (`hive req <url>`).
+   * @param urlOrKey - A URL or issue key identifying the epic
+   * @returns The fetched epic data
+   */
+  fetchEpic(urlOrKey: string): Promise<ExternalEpic>;
+
+  /**
+   * Create a new epic in the PM tool.
+   * @param input - Epic creation data
+   * @returns The created epic reference
+   */
+  createEpic(input: CreateEpicInput): Promise<CreateIssueResult>;
+
+  // ── Story/Issue Operations ──────────────────────────────────────────────
+
+  /**
+   * Create a new story/issue in the PM tool.
+   * @param input - Story creation data
+   * @returns The created issue reference
+   */
+  createStory(input: CreateStoryInput): Promise<CreateIssueResult>;
+
+  /**
+   * Create a subtask under a parent issue (e.g., for agent implementation tracking).
+   * @param input - Subtask creation data
+   * @returns The created subtask reference, or null if creation failed
+   */
+  createSubtask(input: CreateSubtaskInput): Promise<CreateIssueResult | null>;
+
+  /**
+   * Fetch an issue by its key.
+   * @param issueKey - The issue key (e.g., "PROJ-123")
+   * @returns The fetched issue
+   */
+  fetchIssue(issueKey: string): Promise<ExternalIssue>;
+
+  // ── Comments & Progress ─────────────────────────────────────────────────
+
+  /**
+   * Post a lifecycle event comment on an issue.
+   * @param issueKey - Target issue key
+   * @param event - The lifecycle event type
+   * @param context - Additional context for the comment
+   * @returns true if the comment was posted successfully
+   */
+  postComment(
+    issueKey: string,
+    event: LifecycleEvent,
+    context?: LifecycleCommentContext
+  ): Promise<boolean>;
+
+  /**
+   * Post a progress update to a subtask.
+   * @param subtaskKey - The subtask key
+   * @param message - Progress message text
+   * @param agentName - Name of the agent posting the update
+   * @returns true if the update was posted successfully
+   */
+  postProgress(subtaskKey: string, message: string, agentName?: string): Promise<boolean>;
+
+  // ── Status Transitions ──────────────────────────────────────────────────
+
+  /**
+   * Transition an issue to a target status.
+   * The connector should look up available transitions and apply the matching one.
+   * @param issueKey - The issue key to transition
+   * @param targetStatus - The target status name (e.g., "In Progress", "Done")
+   * @returns true if the transition succeeded
+   */
+  transitionStatus(issueKey: string, targetStatus: string): Promise<boolean>;
+
+  /**
+   * Get available transitions for an issue.
+   * @param issueKey - The issue key
+   * @returns List of available transitions
+   */
+  getTransitions(issueKey: string): Promise<ExternalTransition[]>;
+
+  // ── Dependencies ────────────────────────────────────────────────────────
+
+  /**
+   * Create a dependency link between two issues.
+   * @param fromKey - The source issue key
+   * @param toKey - The target issue key
+   * @param linkType - The type of dependency relationship
+   */
+  linkDependency(fromKey: string, toKey: string, linkType: DependencyLinkType): Promise<void>;
+
+  // ── Sprint Operations ───────────────────────────────────────────────────
+
+  /**
+   * Move issues into a sprint/iteration.
+   * @param issueKeys - Issue keys to move
+   * @param sprintId - Target sprint ID
+   */
+  moveToSprint(issueKeys: string[], sprintId: string): Promise<void>;
+
+  /**
+   * Get the active sprint for the configured project/board.
+   * @returns The active sprint, or null if none exists
+   */
+  getActiveSprint(): Promise<ExternalSprint | null>;
+}
+
+// ── Source Code Management Connector ────────────────────────────────────────
+
+/**
+ * Interface for source code management integrations (GitHub, GitLab, Bitbucket, etc.).
+ *
+ * Implementations wrap a specific provider's API for pull/merge request management
+ * and related repository operations.
+ */
+export interface SCMConnector {
+  /** Unique identifier for this connector type (e.g., "github", "gitlab") */
+  readonly type: string;
+
+  /** Human-readable provider name (e.g., "GitHub", "GitLab") */
+  readonly displayName: string;
+
+  /**
+   * Check if the SCM provider is authenticated and ready for operations.
+   * @returns true if authenticated
+   */
+  isAuthenticated(): Promise<boolean>;
+
+  // ── Pull Request Operations ─────────────────────────────────────────────
+
+  /**
+   * Create a new pull/merge request.
+   * @param workDir - Working directory for the repository
+   * @param input - PR creation data
+   * @returns The created PR reference
+   */
+  createPR(workDir: string, input: CreatePRInput): Promise<CreatePRResult>;
+
+  /**
+   * Fetch a pull request by its number.
+   * @param workDir - Working directory for the repository
+   * @param prNumber - The PR number
+   * @returns The fetched PR data
+   */
+  fetchPR(workDir: string, prNumber: number): Promise<ExternalPullRequest>;
+
+  /**
+   * List pull requests by state.
+   * @param workDir - Working directory for the repository
+   * @param state - Filter by PR state
+   * @returns List of matching PRs
+   */
+  listPRs(
+    workDir: string,
+    state?: 'open' | 'closed' | 'all'
+  ): Promise<ExternalPullRequest[]>;
+
+  /**
+   * Merge a pull request.
+   * @param workDir - Working directory for the repository
+   * @param prNumber - The PR number
+   * @param options - Merge options (strategy, branch deletion)
+   */
+  mergePR(workDir: string, prNumber: number, options?: MergePROptions): Promise<void>;
+
+  /**
+   * Close a pull request without merging.
+   * @param workDir - Working directory for the repository
+   * @param prNumber - The PR number
+   */
+  closePR(workDir: string, prNumber: number): Promise<void>;
+
+  // ── Review Operations ───────────────────────────────────────────────────
+
+  /**
+   * Add a reviewer to a pull request.
+   * @param workDir - Working directory for the repository
+   * @param prNumber - The PR number
+   * @param reviewer - Reviewer username/identifier
+   */
+  addReviewer(workDir: string, prNumber: number, reviewer: string): Promise<void>;
+
+  /**
+   * Get reviews on a pull request.
+   * @param workDir - Working directory for the repository
+   * @param prNumber - The PR number
+   * @returns List of reviews
+   */
+  getReviews(workDir: string, prNumber: number): Promise<ExternalPRReview[]>;
+
+  // ── Comments ────────────────────────────────────────────────────────────
+
+  /**
+   * Post a comment on a pull request.
+   * @param workDir - Working directory for the repository
+   * @param prNumber - The PR number
+   * @param body - Comment body text
+   */
+  commentOnPR(workDir: string, prNumber: number, body: string): Promise<void>;
+
+  /**
+   * Get the diff for a pull request.
+   * @param workDir - Working directory for the repository
+   * @param prNumber - The PR number
+   * @returns The unified diff as a string
+   */
+  getPRDiff(workDir: string, prNumber: number): Promise<string>;
+}

--- a/src/connectors/types.ts
+++ b/src/connectors/types.ts
@@ -1,0 +1,336 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+/**
+ * Generic types for project management and source code management connectors.
+ * These types abstract away provider-specific details (Jira, GitHub, etc.)
+ * and provide a unified boundary layer for the Hive orchestrator.
+ */
+
+// ── Issue Status ────────────────────────────────────────────────────────────
+
+/** Generic issue status */
+export interface ExternalStatus {
+  /** Provider-specific status ID */
+  id: string;
+  /** Human-readable status name (e.g., "In Progress", "Done") */
+  name: string;
+  /** Status category for grouping: todo, in_progress, or done */
+  category: 'todo' | 'in_progress' | 'done';
+}
+
+// ── Issue Priority ──────────────────────────────────────────────────────────
+
+/** Generic issue priority */
+export interface ExternalPriority {
+  /** Provider-specific priority ID */
+  id: string;
+  /** Human-readable priority name (e.g., "High", "Medium") */
+  name: string;
+}
+
+// ── User ────────────────────────────────────────────────────────────────────
+
+/** Generic user/assignee from an external provider */
+export interface ExternalUser {
+  /** Provider-specific user ID */
+  id: string;
+  /** Display name */
+  displayName: string;
+  /** Email address (if available) */
+  email?: string;
+}
+
+// ── Issue Type ──────────────────────────────────────────────────────────────
+
+/** Generic issue type */
+export interface ExternalIssueType {
+  /** Provider-specific type ID */
+  id: string;
+  /** Type name (e.g., "Story", "Bug", "Epic", "Subtask") */
+  name: string;
+  /** Whether this is a subtask type */
+  subtask: boolean;
+}
+
+// ── Issue ───────────────────────────────────────────────────────────────────
+
+/** Generic issue from a project management tool */
+export interface ExternalIssue {
+  /** Provider-specific issue ID */
+  id: string;
+  /** Human-readable issue key (e.g., "PROJ-123") */
+  key: string;
+  /** Issue summary/title */
+  summary: string;
+  /** Plain-text description */
+  description: string;
+  /** Current status */
+  status: ExternalStatus;
+  /** Issue type */
+  issueType: ExternalIssueType;
+  /** Priority (if set) */
+  priority?: ExternalPriority;
+  /** Assigned user */
+  assignee?: ExternalUser;
+  /** Reporter/creator */
+  reporter?: ExternalUser;
+  /** Labels/tags */
+  labels: string[];
+  /** Story points (if set) */
+  storyPoints?: number;
+  /** Parent issue key (for subtasks or stories under epics) */
+  parentKey?: string;
+  /** Project identifier */
+  project: {
+    id: string;
+    key: string;
+    name: string;
+  };
+  /** ISO 8601 creation timestamp */
+  createdAt: string;
+  /** ISO 8601 last-updated timestamp */
+  updatedAt: string;
+  /** Direct URL to this issue in the provider UI */
+  url?: string;
+  /** Provider-specific raw data for escape-hatch access */
+  raw?: unknown;
+}
+
+// ── Epic ────────────────────────────────────────────────────────────────────
+
+/** Generic epic from a project management tool */
+export interface ExternalEpic {
+  /** Provider-specific epic ID */
+  id: string;
+  /** Human-readable epic key (e.g., "PROJ-2") */
+  key: string;
+  /** Epic title */
+  title: string;
+  /** Plain-text description */
+  description: string;
+  /** Current status */
+  status: ExternalStatus;
+  /** Labels/tags */
+  labels: string[];
+  /** Project identifier */
+  project: {
+    id: string;
+    key: string;
+    name: string;
+  };
+  /** Direct URL to this epic in the provider UI */
+  url?: string;
+  /** Provider-specific raw data for escape-hatch access */
+  raw?: unknown;
+}
+
+// ── Sprint ──────────────────────────────────────────────────────────────────
+
+/** Generic sprint/iteration */
+export interface ExternalSprint {
+  /** Provider-specific sprint ID */
+  id: string;
+  /** Sprint name */
+  name: string;
+  /** Sprint state */
+  state: 'active' | 'closed' | 'future';
+  /** ISO 8601 start date */
+  startDate?: string;
+  /** ISO 8601 end date */
+  endDate?: string;
+}
+
+// ── Status Transition ───────────────────────────────────────────────────────
+
+/** Available status transition for an issue */
+export interface ExternalTransition {
+  /** Provider-specific transition ID */
+  id: string;
+  /** Transition name (e.g., "Start Progress") */
+  name: string;
+  /** The target status after this transition */
+  to: ExternalStatus;
+}
+
+// ── Comment ─────────────────────────────────────────────────────────────────
+
+/** A comment on an external issue */
+export interface ExternalComment {
+  /** Provider-specific comment ID */
+  id: string;
+  /** Comment author */
+  author: ExternalUser;
+  /** Plain-text comment body */
+  body: string;
+  /** ISO 8601 creation timestamp */
+  createdAt: string;
+}
+
+// ── Pull Request ────────────────────────────────────────────────────────────
+
+/** Generic pull/merge request from an SCM provider */
+export interface ExternalPullRequest {
+  /** Provider-specific PR ID or number */
+  id: string;
+  /** PR number (e.g., 42) */
+  number: number;
+  /** Direct URL to the PR */
+  url: string;
+  /** PR title */
+  title: string;
+  /** PR body/description */
+  body?: string;
+  /** Current state */
+  state: 'open' | 'closed' | 'merged';
+  /** Source branch */
+  headBranch: string;
+  /** Target branch */
+  baseBranch: string;
+  /** Lines added */
+  additions: number;
+  /** Lines deleted */
+  deletions: number;
+  /** Number of changed files */
+  changedFiles: number;
+  /** PR author */
+  author?: ExternalUser;
+  /** Assigned reviewers */
+  reviewers?: ExternalUser[];
+  /** Labels */
+  labels?: string[];
+  /** Whether this is a draft PR */
+  draft?: boolean;
+  /** ISO 8601 creation timestamp */
+  createdAt?: string;
+  /** ISO 8601 last-updated timestamp */
+  updatedAt?: string;
+}
+
+// ── PR Review ───────────────────────────────────────────────────────────────
+
+/** A review on a pull request */
+export interface ExternalPRReview {
+  /** Reviewer identity */
+  author: string;
+  /** Review state */
+  state: 'approved' | 'changes_requested' | 'commented' | 'pending';
+  /** Review body */
+  body: string;
+}
+
+// ── Lifecycle Events ────────────────────────────────────────────────────────
+
+/**
+ * Lifecycle events that connectors can post as comments/updates.
+ * Provider-agnostic equivalent of JiraLifecycleEvent.
+ */
+export type LifecycleEvent =
+  | 'assigned'
+  | 'work_started'
+  | 'progress'
+  | 'approach_posted'
+  | 'pr_created'
+  | 'qa_started'
+  | 'qa_passed'
+  | 'qa_failed'
+  | 'merged'
+  | 'blocked';
+
+/** Context for posting lifecycle event comments */
+export interface LifecycleCommentContext {
+  agentName?: string;
+  branchName?: string;
+  prUrl?: string;
+  reason?: string;
+  subtaskKey?: string;
+  approachText?: string;
+}
+
+// ── Input Types for Connector Methods ───────────────────────────────────────
+
+/** Input for creating an epic */
+export interface CreateEpicInput {
+  /** Epic title/summary */
+  title: string;
+  /** Description in plain text */
+  description: string;
+  /** Labels to apply */
+  labels?: string[];
+}
+
+/** Input for creating a story/issue */
+export interface CreateStoryInput {
+  /** Story title/summary */
+  title: string;
+  /** Description in plain text */
+  description: string;
+  /** Parent epic key (if linking to an epic) */
+  epicKey?: string;
+  /** Story points */
+  storyPoints?: number;
+  /** Priority name */
+  priority?: string;
+  /** Labels to apply */
+  labels?: string[];
+  /** Acceptance criteria (plain text items) */
+  acceptanceCriteria?: string[];
+}
+
+/** Input for creating a subtask */
+export interface CreateSubtaskInput {
+  /** Parent issue key */
+  parentIssueKey: string;
+  /** Agent name performing the implementation */
+  agentName: string;
+  /** Parent story title */
+  storyTitle: string;
+  /** Implementation approach steps */
+  approachSteps?: string[];
+}
+
+/** Input for creating a pull request */
+export interface CreatePRInput {
+  /** PR title */
+  title: string;
+  /** PR body/description */
+  body: string;
+  /** Target/base branch */
+  baseBranch: string;
+  /** Source/head branch */
+  headBranch: string;
+  /** Whether to create as draft */
+  draft?: boolean;
+  /** Labels to apply */
+  labels?: string[];
+  /** Users to assign to the PR */
+  assignees?: string[];
+}
+
+/** Options for merging a pull request */
+export interface MergePROptions {
+  /** Merge strategy */
+  method?: 'merge' | 'squash' | 'rebase';
+  /** Whether to delete the branch after merge */
+  deleteBranch?: boolean;
+}
+
+/** Result of creating an issue/epic/subtask */
+export interface CreateIssueResult {
+  /** Provider-specific ID */
+  id: string;
+  /** Human-readable key (e.g., "PROJ-123") */
+  key: string;
+  /** Direct URL to the created issue */
+  url?: string;
+}
+
+/** Result of creating a pull request */
+export interface CreatePRResult {
+  /** PR number */
+  number: number;
+  /** Direct URL to the PR */
+  url: string;
+}
+
+/** Link type for issue dependencies */
+export type DependencyLinkType = 'blocks' | 'is_blocked_by' | 'relates_to';


### PR DESCRIPTION
## Summary
- Define `ProjectManagementConnector` interface with methods: createEpic, createStory, createSubtask, postComment, postProgress, transitionStatus, linkDependency, moveToSprint, fetchEpic, fetchIssue, getTransitions, getActiveSprint, authenticate, recognizesUrl
- Define `SCMConnector` interface with methods: createPR, mergePR, closePR, addReviewer, fetchPR, listPRs, commentOnPR, getReviews, getPRDiff, isAuthenticated
- Create generic types: ExternalIssue, ExternalEpic, ExternalSprint, ExternalPullRequest, ExternalStatus, ExternalUser, ExternalTransition, ExternalComment, ExternalPRReview
- Create input/result types: CreateEpicInput, CreateStoryInput, CreateSubtaskInput, CreatePRInput, CreateIssueResult, CreatePRResult, MergePROptions
- Add LifecycleEvent type and LifecycleCommentContext matching existing Jira lifecycle events
- 30 tests validating interface implementability and type correctness

Story: STORY-INPKQU

## Test plan
- [x] All 30 new connector interface tests pass
- [x] Full test suite (1172 tests across 66 files) passes
- [x] TypeScript type-check passes with 0 errors
- [x] ESLint passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)