### PR TITLE
fix: prevent Jira sync regressions, fix epic/subtask linking, verbose dev comments

### DIFF
--- a/src/orchestrator/prompt-templates.ts
+++ b/src/orchestrator/prompt-templates.ts
@@ -147,21 +147,33 @@ hive my-stories refactor --session ${sessionName} --title "<short title>" --desc
 \`\`\`
 Include affected files and rationale in the description. Refactor stories are scheduled using the team's configured refactor capacity budget.
 
-## Jira Progress Updates
-Post progress updates to your Jira subtask at key milestones so the team can track your work:
+## Jira Progress Updates — Be Verbose!
+You MUST post frequent, detailed progress updates to your Jira subtask. The team relies on these comments to understand what you're doing and why. Post an update for EVERY significant decision or milestone:
 \`\`\`bash
 # After creating your feature branch
-hive progress <story-id> -m "Branch created, starting implementation" --from ${sessionName}
+hive progress <story-id> -m "Branch created off origin/main. Starting with codebase exploration." --from ${sessionName}
+
+# After exploring the codebase — explain what you found
+hive progress <story-id> -m "Explored codebase: found X in file Y. Will modify Z because [reason]. Alternative approach considered: [what], rejected because [why]." --from ${sessionName}
+
+# When making key implementation decisions
+hive progress <story-id> -m "Decision: using [approach] because [rationale]. Files affected: [list]. Potential risks: [list]." --from ${sessionName}
 
 # After tests pass locally
-hive progress <story-id> -m "Implementation complete, all tests passing" --from ${sessionName}
+hive progress <story-id> -m "Implementation complete. Changed [N] files: [list key changes]. All [N] tests passing. Added [N] new tests for [what]." --from ${sessionName}
 
 # Before creating the PR
-hive progress <story-id> -m "Creating pull request for review" --from ${sessionName}
+hive progress <story-id> -m "Creating pull request. Summary of all changes: [brief summary]." --from ${sessionName}
 
 # When done (transitions subtask to Done)
 hive progress <story-id> -m "PR submitted to merge queue" --from ${sessionName} --done
 \`\`\`
+
+**IMPORTANT:** Do NOT just post generic one-liners. Every progress update should include:
+- What you did and what you decided
+- Why you chose this approach over alternatives
+- What files you changed and why
+- Any risks, assumptions, or trade-offs
 
 ## Guidelines
 - Follow existing code patterns in the repository
@@ -281,21 +293,33 @@ hive my-stories refactor --session ${sessionName} --title "<short title>" --desc
 \`\`\`
 Include affected files and rationale in the description. Refactor stories are scheduled using the team's configured refactor capacity budget.
 
-## Jira Progress Updates
-Post progress updates to your Jira subtask at key milestones so the team can track your work:
+## Jira Progress Updates — Be Verbose!
+You MUST post frequent, detailed progress updates to your Jira subtask. The team relies on these comments to understand what you're doing and why. Post an update for EVERY significant decision or milestone:
 \`\`\`bash
 # After creating your feature branch
-hive progress <story-id> -m "Branch created, starting implementation" --from ${sessionName}
+hive progress <story-id> -m "Branch created off origin/main. Starting with codebase exploration." --from ${sessionName}
+
+# After exploring the codebase — explain what you found
+hive progress <story-id> -m "Explored codebase: found X in file Y. Will modify Z because [reason]. Alternative approach considered: [what], rejected because [why]." --from ${sessionName}
+
+# When making key implementation decisions
+hive progress <story-id> -m "Decision: using [approach] because [rationale]. Files affected: [list]. Potential risks: [list]." --from ${sessionName}
 
 # After tests pass locally
-hive progress <story-id> -m "Implementation complete, all tests passing" --from ${sessionName}
+hive progress <story-id> -m "Implementation complete. Changed [N] files: [list key changes]. All [N] tests passing. Added [N] new tests for [what]." --from ${sessionName}
 
 # Before creating the PR
-hive progress <story-id> -m "Creating pull request for review" --from ${sessionName}
+hive progress <story-id> -m "Creating pull request. Summary of all changes: [brief summary]." --from ${sessionName}
 
 # When done (transitions subtask to Done)
 hive progress <story-id> -m "PR submitted to merge queue" --from ${sessionName} --done
 \`\`\`
+
+**IMPORTANT:** Do NOT just post generic one-liners. Every progress update should include:
+- What you did and what you decided
+- Why you chose this approach over alternatives
+- What files you changed and why
+- Any risks, assumptions, or trade-offs
 
 ## Guidelines
 - Follow existing code patterns
@@ -415,21 +439,33 @@ hive my-stories refactor --session ${sessionName} --title "<short title>" --desc
 \`\`\`
 Include affected files and rationale in the description. Refactor stories are scheduled using the team's configured refactor capacity budget.
 
-## Jira Progress Updates
-Post progress updates to your Jira subtask at key milestones so the team can track your work:
+## Jira Progress Updates — Be Verbose!
+You MUST post frequent, detailed progress updates to your Jira subtask. The team relies on these comments to understand what you're doing and why. Post an update for EVERY significant decision or milestone:
 \`\`\`bash
 # After creating your feature branch
-hive progress <story-id> -m "Branch created, starting implementation" --from ${sessionName}
+hive progress <story-id> -m "Branch created off origin/main. Starting with codebase exploration." --from ${sessionName}
+
+# After exploring the codebase — explain what you found
+hive progress <story-id> -m "Explored codebase: found X in file Y. Will modify Z because [reason]. Alternative approach considered: [what], rejected because [why]." --from ${sessionName}
+
+# When making key implementation decisions
+hive progress <story-id> -m "Decision: using [approach] because [rationale]. Files affected: [list]. Potential risks: [list]." --from ${sessionName}
 
 # After tests pass locally
-hive progress <story-id> -m "Implementation complete, all tests passing" --from ${sessionName}
+hive progress <story-id> -m "Implementation complete. Changed [N] files: [list key changes]. All [N] tests passing. Added [N] new tests for [what]." --from ${sessionName}
 
 # Before creating the PR
-hive progress <story-id> -m "Creating pull request for review" --from ${sessionName}
+hive progress <story-id> -m "Creating pull request. Summary of all changes: [brief summary]." --from ${sessionName}
 
 # When done (transitions subtask to Done)
 hive progress <story-id> -m "PR submitted to merge queue" --from ${sessionName} --done
 \`\`\`
+
+**IMPORTANT:** Do NOT just post generic one-liners. Every progress update should include:
+- What you did and what you decided
+- Why you chose this approach over alternatives
+- What files you changed and why
+- Any risks, assumptions, or trade-offs
 
 ## Guidelines
 - Follow existing patterns exactly


### PR DESCRIPTION
## Summary
- **Prevent backward status transitions**: Jira→Hive sync was overwriting story statuses backward (e.g., `in_progress` → `planned` when Jira had "To Do"). Added `isForwardTransition()` guard with pipeline ordering.
- **Fix subtask creation**: `handleJiraAfterAssignment()` was using a stale story object without `jira_issue_key`. Now re-fetches from DB so subtasks are created correctly.
- **Fix epic duplication**: Tech Lead's `syncToJiraIfEnabled()` was using a stale requirement without `jira_epic_key`/`jira_epic_id` set by `hive req <epic-url>`. Now re-fetches from DB so existing epics are linked instead of duplicated.
- **Verbose developer comments**: Updated all developer prompt templates (Senior, Intermediate, Junior) to require detailed Jira progress updates with decisions, rationale, files changed, and trade-offs.
- **Jira setup wizard**: Added "Provide a board URL/link" option, graceful error handling for missing Jira Software permissions on board fetch.

## Test plan
- [x] All 1147 tests pass (65 test files)
- [x] Added `isForwardTransition` unit tests (forward, backward, same-status, qa_failed edge cases)
- [x] Added backward-transition integration test for `syncJiraStatusesToHive`
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] ESLint passes on all changed files
- [x] Prettier formatting passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)