### PR TITLE
fix: auto-sync stories to Jira when missing jira_issue_key

### DIFF
--- a/src/cli/commands/assign.ts
+++ b/src/cli/commands/assign.ts
@@ -156,6 +156,14 @@ export const assignCommand = new Command('assign')
           spinner.succeed(chalk.green(summaryMsg));
         }
 
+        // Wait for all Jira operations (subtask creation, status transitions) to complete
+        // before the DB is closed by withHiveContext
+        if (result.assigned > 0) {
+          spinner.text = 'Syncing with Jira...';
+          await scheduler.flushJiraQueue();
+          db.save();
+        }
+
         // Determine if we should start the manager, but don't start it yet
         // Wait until after withHiveContext closes the DB to prevent race condition
         if (result.assigned > 0) {

--- a/src/cli/commands/manager.ts
+++ b/src/cli/commands/manager.ts
@@ -568,8 +568,9 @@ async function syncJiraStatuses(ctx: ManagerCheckContext): Promise<void> {
   if (syncedStories > 0) {
     ctx.counters.jiraSynced = syncedStories;
     console.log(chalk.cyan(`  Synced ${syncedStories} story status(es) from Jira`));
-    ctx.db.save();
   }
+  // Always save after Jira sync — syncFromJira now also pushes unsynced stories TO Jira
+  ctx.db.save();
 }
 
 function getRequirementKey(requirementId: string | null): string {

--- a/src/orchestrator/scheduler.ts
+++ b/src/orchestrator/scheduler.ts
@@ -96,6 +96,14 @@ export class Scheduler {
   }
 
   /**
+   * Wait for all pending Jira operations to complete.
+   * Call this before closing the database to prevent "Database closed" errors.
+   */
+  async flushJiraQueue(): Promise<void> {
+    await this.jiraQueue.waitForCompletion();
+  }
+
+  /**
    * Create a git worktree for an agent
    * Returns the worktree path
    */


### PR DESCRIPTION
## Summary
- Stories inserted directly into the DB (e.g., by the tech lead via SQL) bypassed the Jira sync flow, leaving them without Jira issue keys and invisible on Jira boards
- Adds `syncUnsyncedStoriesToJira()` that detects stories without `jira_issue_key` and creates Jira issues under the requirement's epic
- Hooks into the manager daemon's periodic sync — `syncFromJira()` now pushes unsynced stories TO Jira before pulling statuses FROM Jira
- Also includes: `flushJiraQueue()` on scheduler, status regression guard, Jira queue flush in assign command

## Test plan
- [x] 14 tests pass in `sync.test.ts` (5 new tests for unsynced story sync)
- [x] All 1147 tests pass across 65 test files
- [x] TypeScript compiles clean
- [x] ESLint: 0 errors (7 pre-existing warnings in other files)
- [x] Prettier formatting verified
- [ ] Manual: create stories via SQL without Jira keys → run manager → verify stories appear in Jira

🤖 Generated with [Claude Code](https://claude.com/claude-code)