### PR TITLE
feat: define connector abstraction layer

### DIFF
--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -1,0 +1,5 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+export * from './types.js';
+export { ConnectorRegistry } from './registry.js';
+export type { SourceControlFactory, ProjectManagementFactory } from './registry.js';

--- a/src/connectors/registry.test.ts
+++ b/src/connectors/registry.test.ts
@@ -1,0 +1,301 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { HiveConfig } from '../config/schema.js';
+import { ConnectorRegistry } from './registry.js';
+import type {
+  ConnectorConfig,
+  ProjectManagementConnector,
+  SourceControlConnector,
+} from './types.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeMockSCConnector(name: string): SourceControlConnector {
+  return {
+    displayName: name.charAt(0).toUpperCase() + name.slice(1),
+    name,
+    auth: {
+      authenticate: async () => {},
+      refreshToken: async () => {},
+      isAuthenticated: async () => true,
+      getTokens: () => ({}),
+    },
+    createPR: async () => ({ number: 1, url: 'https://example.com/pr/1' }),
+    getPR: async () => ({
+      number: 1,
+      url: 'https://example.com/pr/1',
+      title: 'test',
+      state: 'open' as const,
+      headBranch: 'feat',
+      baseBranch: 'main',
+      additions: 0,
+      deletions: 0,
+      changedFiles: 0,
+    }),
+    listPRs: async () => [],
+    mergePR: async () => {},
+    commentOnPR: async () => {},
+    reviewPR: async () => {},
+  };
+}
+
+function makeMockPMConnector(name: string): ProjectManagementConnector {
+  return {
+    displayName: name.charAt(0).toUpperCase() + name.slice(1),
+    name,
+    auth: {
+      authenticate: async () => {},
+      refreshToken: async () => {},
+      isAuthenticated: async () => true,
+      getTokens: () => ({}),
+    },
+    fetchIssue: async () => ({
+      id: '1',
+      key: 'PROJ-1',
+      title: 'test',
+      description: '',
+      status: 'To Do',
+      type: 'Story',
+      labels: [],
+    }),
+    searchIssues: async () => [],
+    createIssue: async () => ({ id: '1', key: 'PROJ-1' }),
+    updateIssue: async () => {},
+    transitionIssue: async () => true,
+    syncStatuses: async () => 0,
+    importEpic: async () => ({ key: 'PROJ-1', id: '1', title: 'Epic', description: '' }),
+    parseEpicRef: () => null,
+    isEpicRef: () => false,
+  };
+}
+
+function makeMinimalConfig(
+  scProvider: string = 'github',
+  pmProvider: string = 'none'
+): HiveConfig {
+  return {
+    integrations: {
+      source_control: { provider: scProvider },
+      project_management: { provider: pmProvider },
+      autonomy: { level: 'full' },
+    },
+  } as unknown as HiveConfig;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ConnectorRegistry', () => {
+  beforeEach(() => {
+    ConnectorRegistry.resetInstance();
+  });
+
+  afterEach(() => {
+    ConnectorRegistry.resetInstance();
+  });
+
+  // ── Singleton ───────────────────────────────────────────────────────────
+
+  describe('singleton', () => {
+    it('should return the same instance', () => {
+      const a = ConnectorRegistry.getInstance();
+      const b = ConnectorRegistry.getInstance();
+      expect(a).toBe(b);
+    });
+
+    it('should return a fresh instance after resetInstance()', () => {
+      const a = ConnectorRegistry.getInstance();
+      ConnectorRegistry.resetInstance();
+      const b = ConnectorRegistry.getInstance();
+      expect(a).not.toBe(b);
+    });
+  });
+
+  // ── Registration ────────────────────────────────────────────────────────
+
+  describe('registerSourceControl', () => {
+    it('should register a source control factory', () => {
+      const registry = ConnectorRegistry.getInstance();
+      registry.registerSourceControl('github', () => makeMockSCConnector('github'));
+
+      expect(registry.hasSourceControl('github')).toBe(true);
+      expect(registry.hasSourceControl('gitlab')).toBe(false);
+    });
+
+    it('should list registered source control names', () => {
+      const registry = ConnectorRegistry.getInstance();
+      registry.registerSourceControl('github', () => makeMockSCConnector('github'));
+      registry.registerSourceControl('gitlab', () => makeMockSCConnector('gitlab'));
+
+      const names = registry.getRegisteredSourceControlNames();
+      expect(names).toContain('github');
+      expect(names).toContain('gitlab');
+      expect(names).toHaveLength(2);
+    });
+  });
+
+  describe('registerProjectManagement', () => {
+    it('should register a project management factory', () => {
+      const registry = ConnectorRegistry.getInstance();
+      registry.registerProjectManagement('jira', () => makeMockPMConnector('jira'));
+
+      expect(registry.hasProjectManagement('jira')).toBe(true);
+      expect(registry.hasProjectManagement('monday')).toBe(false);
+    });
+
+    it('should list registered project management names', () => {
+      const registry = ConnectorRegistry.getInstance();
+      registry.registerProjectManagement('jira', () => makeMockPMConnector('jira'));
+      registry.registerProjectManagement('monday', () => makeMockPMConnector('monday'));
+
+      const names = registry.getRegisteredProjectManagementNames();
+      expect(names).toContain('jira');
+      expect(names).toContain('monday');
+      expect(names).toHaveLength(2);
+    });
+  });
+
+  // ── Retrieval ───────────────────────────────────────────────────────────
+
+  describe('getSourceControl', () => {
+    it('should throw when no connector is initialized', () => {
+      const registry = ConnectorRegistry.getInstance();
+      expect(() => registry.getSourceControl()).toThrow(
+        'No source control connector initialized'
+      );
+    });
+  });
+
+  describe('getProjectManagement', () => {
+    it('should return null when no PM connector is initialized', () => {
+      const registry = ConnectorRegistry.getInstance();
+      expect(registry.getProjectManagement()).toBeNull();
+    });
+  });
+
+  // ── initializeFromConfig ────────────────────────────────────────────────
+
+  describe('initializeFromConfig', () => {
+    it('should initialize source control connector from config', () => {
+      const registry = ConnectorRegistry.getInstance();
+      let receivedConfig: ConnectorConfig | null = null;
+
+      registry.registerSourceControl('github', (config) => {
+        receivedConfig = config;
+        return makeMockSCConnector('github');
+      });
+
+      const config = makeMinimalConfig('github', 'none');
+      registry.initializeFromConfig(config);
+
+      const sc = registry.getSourceControl();
+      expect(sc.name).toBe('github');
+      expect(receivedConfig).not.toBeNull();
+      expect(receivedConfig!.name).toBe('github');
+    });
+
+    it('should initialize PM connector when provider is not "none"', () => {
+      const registry = ConnectorRegistry.getInstance();
+      registry.registerSourceControl('github', () => makeMockSCConnector('github'));
+      registry.registerProjectManagement('jira', () => makeMockPMConnector('jira'));
+
+      registry.initializeFromConfig(makeMinimalConfig('github', 'jira'));
+
+      const pm = registry.getProjectManagement();
+      expect(pm).not.toBeNull();
+      expect(pm!.name).toBe('jira');
+    });
+
+    it('should set PM to null when provider is "none"', () => {
+      const registry = ConnectorRegistry.getInstance();
+      registry.registerSourceControl('github', () => makeMockSCConnector('github'));
+
+      registry.initializeFromConfig(makeMinimalConfig('github', 'none'));
+
+      expect(registry.getProjectManagement()).toBeNull();
+    });
+
+    it('should throw when SC provider is not registered', () => {
+      const registry = ConnectorRegistry.getInstance();
+      expect(() => registry.initializeFromConfig(makeMinimalConfig('gitlab', 'none'))).toThrow(
+        'Source control provider "gitlab" is not registered'
+      );
+    });
+
+    it('should throw when PM provider is not registered', () => {
+      const registry = ConnectorRegistry.getInstance();
+      registry.registerSourceControl('github', () => makeMockSCConnector('github'));
+
+      expect(() =>
+        registry.initializeFromConfig(makeMinimalConfig('github', 'monday'))
+      ).toThrow('Project management provider "monday" is not registered');
+    });
+
+    it('should include available providers in error messages', () => {
+      const registry = ConnectorRegistry.getInstance();
+      registry.registerSourceControl('github', () => makeMockSCConnector('github'));
+      registry.registerProjectManagement('jira', () => makeMockPMConnector('jira'));
+
+      expect(() =>
+        registry.initializeFromConfig(makeMinimalConfig('github', 'monday'))
+      ).toThrow('Available: [jira]');
+    });
+
+    it('should pass the full config to the factory', () => {
+      const registry = ConnectorRegistry.getInstance();
+      let receivedConfig: ConnectorConfig | null = null;
+
+      registry.registerSourceControl('github', (config) => {
+        receivedConfig = config;
+        return makeMockSCConnector('github');
+      });
+
+      const config = makeMinimalConfig('github', 'none');
+      registry.initializeFromConfig(config);
+
+      // The factory receives a spread of { name, ...config }
+      expect(receivedConfig).not.toBeNull();
+      expect(receivedConfig!.name).toBe('github');
+      expect((receivedConfig as any).integrations).toBeDefined();
+    });
+  });
+
+  // ── reset() ─────────────────────────────────────────────────────────────
+
+  describe('reset', () => {
+    it('should clear all factories and active connectors', () => {
+      const registry = ConnectorRegistry.getInstance();
+      registry.registerSourceControl('github', () => makeMockSCConnector('github'));
+      registry.registerProjectManagement('jira', () => makeMockPMConnector('jira'));
+      registry.initializeFromConfig(makeMinimalConfig('github', 'jira'));
+
+      // Verify connectors are active
+      expect(registry.getSourceControl().name).toBe('github');
+      expect(registry.getProjectManagement()?.name).toBe('jira');
+
+      registry.reset();
+
+      // Everything should be cleared
+      expect(registry.hasSourceControl('github')).toBe(false);
+      expect(registry.hasProjectManagement('jira')).toBe(false);
+      expect(registry.getRegisteredSourceControlNames()).toHaveLength(0);
+      expect(registry.getRegisteredProjectManagementNames()).toHaveLength(0);
+      expect(() => registry.getSourceControl()).toThrow();
+      expect(registry.getProjectManagement()).toBeNull();
+    });
+  });
+
+  // ── Overwrite registration ──────────────────────────────────────────────
+
+  describe('overwriting registrations', () => {
+    it('should allow overwriting a registered factory', () => {
+      const registry = ConnectorRegistry.getInstance();
+      registry.registerSourceControl('github', () => makeMockSCConnector('github-v1'));
+      registry.registerSourceControl('github', () => makeMockSCConnector('github-v2'));
+
+      registry.initializeFromConfig(makeMinimalConfig('github', 'none'));
+      // Should use the latest registered factory
+      expect(registry.getSourceControl().name).toBe('github-v2');
+    });
+  });
+});

--- a/src/connectors/registry.ts
+++ b/src/connectors/registry.ts
@@ -1,0 +1,142 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+/**
+ * ConnectorRegistry — singleton that manages source control and project
+ * management connector instances.
+ *
+ * Connectors register themselves by name; consumer code retrieves the
+ * active connector without knowing which provider is in use.
+ */
+
+import type { HiveConfig } from '../config/schema.js';
+import type {
+  ConnectorConfig,
+  ProjectManagementConnector,
+  SourceControlConnector,
+} from './types.js';
+
+/** Factory function that creates a connector from its config section. */
+export type SourceControlFactory = (config: ConnectorConfig) => SourceControlConnector;
+export type ProjectManagementFactory = (config: ConnectorConfig) => ProjectManagementConnector;
+
+export class ConnectorRegistry {
+  // ── Singleton ───────────────────────────────────────────────────────────
+
+  private static instance: ConnectorRegistry | null = null;
+
+  static getInstance(): ConnectorRegistry {
+    if (!ConnectorRegistry.instance) {
+      ConnectorRegistry.instance = new ConnectorRegistry();
+    }
+    return ConnectorRegistry.instance;
+  }
+
+  /** Reset the singleton (useful for testing). */
+  static resetInstance(): void {
+    ConnectorRegistry.instance = null;
+  }
+
+  // ── Internal state ──────────────────────────────────────────────────────
+
+  private sourceControlFactories = new Map<string, SourceControlFactory>();
+  private projectManagementFactories = new Map<string, ProjectManagementFactory>();
+
+  private activeSourceControl: SourceControlConnector | null = null;
+  private activeProjectManagement: ProjectManagementConnector | null = null;
+
+  // ── Registration ────────────────────────────────────────────────────────
+
+  /** Register a source control connector factory by name. */
+  registerSourceControl(name: string, factory: SourceControlFactory): void {
+    this.sourceControlFactories.set(name, factory);
+  }
+
+  /** Register a project management connector factory by name. */
+  registerProjectManagement(name: string, factory: ProjectManagementFactory): void {
+    this.projectManagementFactories.set(name, factory);
+  }
+
+  // ── Retrieval ───────────────────────────────────────────────────────────
+
+  /** Get the active source control connector. Throws if none initialized. */
+  getSourceControl(): SourceControlConnector {
+    if (!this.activeSourceControl) {
+      throw new Error(
+        'No source control connector initialized. Call initializeFromConfig() first.'
+      );
+    }
+    return this.activeSourceControl;
+  }
+
+  /** Get the active project management connector, or null if none configured. */
+  getProjectManagement(): ProjectManagementConnector | null {
+    return this.activeProjectManagement;
+  }
+
+  // ── Discovery ───────────────────────────────────────────────────────────
+
+  /** List registered source control connector names. */
+  getRegisteredSourceControlNames(): string[] {
+    return [...this.sourceControlFactories.keys()];
+  }
+
+  /** List registered project management connector names. */
+  getRegisteredProjectManagementNames(): string[] {
+    return [...this.projectManagementFactories.keys()];
+  }
+
+  /** Check whether a source control connector is registered by name. */
+  hasSourceControl(name: string): boolean {
+    return this.sourceControlFactories.has(name);
+  }
+
+  /** Check whether a project management connector is registered by name. */
+  hasProjectManagement(name: string): boolean {
+    return this.projectManagementFactories.has(name);
+  }
+
+  // ── Initialization ──────────────────────────────────────────────────────
+
+  /**
+   * Read provider names from the Hive config, look up registered factories,
+   * and instantiate the active connectors.
+   */
+  initializeFromConfig(config: HiveConfig): void {
+    const scProvider = config.integrations.source_control.provider;
+    const pmProvider = config.integrations.project_management.provider;
+
+    // Source control (required)
+    const scFactory = this.sourceControlFactories.get(scProvider);
+    if (!scFactory) {
+      throw new Error(
+        `Source control provider "${scProvider}" is not registered. ` +
+          `Available: [${this.getRegisteredSourceControlNames().join(', ')}]`
+      );
+    }
+    this.activeSourceControl = scFactory({ name: scProvider, ...config });
+
+    // Project management (optional — "none" means no PM)
+    if (pmProvider && pmProvider !== 'none') {
+      const pmFactory = this.projectManagementFactories.get(pmProvider);
+      if (!pmFactory) {
+        throw new Error(
+          `Project management provider "${pmProvider}" is not registered. ` +
+            `Available: [${this.getRegisteredProjectManagementNames().join(', ')}]`
+        );
+      }
+      this.activeProjectManagement = pmFactory({ name: pmProvider, ...config });
+    } else {
+      this.activeProjectManagement = null;
+    }
+  }
+
+  // ── Reset ───────────────────────────────────────────────────────────────
+
+  /** Clear all registered factories and active instances (useful for testing). */
+  reset(): void {
+    this.sourceControlFactories.clear();
+    this.projectManagementFactories.clear();
+    this.activeSourceControl = null;
+    this.activeProjectManagement = null;
+  }
+}

--- a/src/connectors/types.test.ts
+++ b/src/connectors/types.test.ts
@@ -1,0 +1,188 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import { describe, expect, it } from 'vitest';
+import {
+  ConnectorType,
+  type ConnectorAuth,
+  type ConnectorConfig,
+  type ExternalEpic,
+  type ExternalIssue,
+  type PRCreateOptions,
+  type PRInfo,
+  type PRMergeOptions,
+  type PRReview,
+  type ProjectManagementConnector,
+  type SourceControlConnector,
+} from './types.js';
+
+describe('ConnectorType enum', () => {
+  it('should contain source control provider values', () => {
+    expect(ConnectorType.GitHub).toBe('github');
+    expect(ConnectorType.GitLab).toBe('gitlab');
+    expect(ConnectorType.Bitbucket).toBe('bitbucket');
+  });
+
+  it('should contain project management provider values', () => {
+    expect(ConnectorType.Jira).toBe('jira');
+    expect(ConnectorType.Monday).toBe('monday');
+    expect(ConnectorType.Linear).toBe('linear');
+  });
+});
+
+describe('ConnectorConfig', () => {
+  it('should accept a config with name and arbitrary keys', () => {
+    const config: ConnectorConfig = {
+      name: 'github',
+      base_branch: 'main',
+      extra: 42,
+    };
+    expect(config.name).toBe('github');
+    expect(config.base_branch).toBe('main');
+  });
+});
+
+describe('ConnectorAuth interface', () => {
+  it('should be implementable', async () => {
+    const auth: ConnectorAuth = {
+      authenticate: async () => {},
+      refreshToken: async () => {},
+      isAuthenticated: async () => true,
+      getTokens: () => ({ token: 'abc' }),
+    };
+
+    expect(await auth.isAuthenticated()).toBe(true);
+    expect(auth.getTokens()).toEqual({ token: 'abc' });
+  });
+});
+
+describe('SourceControlConnector interface', () => {
+  it('should be implementable with all required methods', async () => {
+    const mockPR: PRInfo = {
+      number: 1,
+      url: 'https://github.com/org/repo/pull/1',
+      title: 'feat: add feature',
+      state: 'open',
+      headBranch: 'feature/test',
+      baseBranch: 'main',
+      additions: 10,
+      deletions: 2,
+      changedFiles: 3,
+    };
+
+    const connector: SourceControlConnector = {
+      displayName: 'GitHub',
+      name: 'github',
+      auth: {
+        authenticate: async () => {},
+        refreshToken: async () => {},
+        isAuthenticated: async () => true,
+        getTokens: () => ({ GITHUB_TOKEN: 'ghp_xxx' }),
+      },
+      createPR: async (_workDir: string, _options: PRCreateOptions) => ({
+        number: 1,
+        url: 'https://github.com/org/repo/pull/1',
+      }),
+      getPR: async () => mockPR,
+      listPRs: async () => [mockPR],
+      mergePR: async (_workDir: string, _prNumber: number, _options?: PRMergeOptions) => {},
+      commentOnPR: async () => {},
+      reviewPR: async (_workDir: string, _prNumber: number, _review: PRReview) => {},
+    };
+
+    expect(connector.name).toBe('github');
+    expect(connector.displayName).toBe('GitHub');
+
+    const created = await connector.createPR('/tmp', {
+      title: 'test',
+      body: 'body',
+      baseBranch: 'main',
+      headBranch: 'feature',
+    });
+    expect(created.number).toBe(1);
+
+    const pr = await connector.getPR('/tmp', 1);
+    expect(pr.state).toBe('open');
+
+    const prs = await connector.listPRs('/tmp', 'open');
+    expect(prs).toHaveLength(1);
+  });
+});
+
+describe('ProjectManagementConnector interface', () => {
+  it('should be implementable with all required methods', async () => {
+    const mockIssue: ExternalIssue = {
+      id: '10001',
+      key: 'PROJ-1',
+      title: 'Test story',
+      description: 'A test story description',
+      status: 'To Do',
+      type: 'Story',
+      labels: ['hive-managed'],
+    };
+
+    const mockEpic: ExternalEpic = {
+      key: 'PROJ-100',
+      id: '10100',
+      title: 'Test epic',
+      description: 'An epic description',
+    };
+
+    const connector: ProjectManagementConnector = {
+      displayName: 'Jira',
+      name: 'jira',
+      auth: {
+        authenticate: async () => {},
+        refreshToken: async () => {},
+        isAuthenticated: async () => true,
+        getTokens: () => ({ JIRA_ACCESS_TOKEN: 'tok' }),
+      },
+      fetchIssue: async () => mockIssue,
+      searchIssues: async () => [mockIssue],
+      createIssue: async () => ({ id: '10001', key: 'PROJ-1' }),
+      updateIssue: async () => {},
+      transitionIssue: async () => true,
+      syncStatuses: async () => 3,
+      importEpic: async () => mockEpic,
+      parseEpicRef: (url: string) => {
+        if (url.includes('atlassian.net')) {
+          return { issueKey: 'PROJ-100', siteUrl: 'https://mysite.atlassian.net' };
+        }
+        return null;
+      },
+      isEpicRef: (value: string) => value.includes('atlassian.net'),
+    };
+
+    expect(connector.name).toBe('jira');
+    expect(connector.displayName).toBe('Jira');
+
+    const issue = await connector.fetchIssue('PROJ-1');
+    expect(issue.key).toBe('PROJ-1');
+    expect(issue.title).toBe('Test story');
+
+    const results = await connector.searchIssues({ query: 'project = PROJ', maxResults: 10 });
+    expect(results).toHaveLength(1);
+
+    const created = await connector.createIssue({
+      projectKey: 'PROJ',
+      title: 'New story',
+      type: 'Story',
+    });
+    expect(created.key).toBe('PROJ-1');
+
+    const transitioned = await connector.transitionIssue('PROJ-1', 'In Progress');
+    expect(transitioned).toBe(true);
+
+    const syncCount = await connector.syncStatuses({ 'To Do': 'draft' });
+    expect(syncCount).toBe(3);
+
+    const epic = await connector.importEpic('https://mysite.atlassian.net/browse/PROJ-100');
+    expect(epic.key).toBe('PROJ-100');
+
+    const parsed = connector.parseEpicRef('https://mysite.atlassian.net/browse/PROJ-100');
+    expect(parsed).toEqual({ issueKey: 'PROJ-100', siteUrl: 'https://mysite.atlassian.net' });
+
+    expect(connector.parseEpicRef('not-a-url')).toBeNull();
+    expect(connector.isEpicRef('https://mysite.atlassian.net/browse/PROJ-100')).toBe(true);
+    expect(connector.isEpicRef('not-a-url')).toBe(false);
+  });
+});

--- a/src/connectors/types.ts
+++ b/src/connectors/types.ts
@@ -1,0 +1,210 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+/**
+ * Connector abstraction layer — foundational interfaces and types.
+ *
+ * These interfaces decouple the orchestrator from specific providers (GitHub,
+ * Jira, GitLab, Monday, etc.) so that any implementation can be swapped in
+ * via the ConnectorRegistry.
+ */
+
+// ── Connector Type Enum ─────────────────────────────────────────────────────
+
+/** Known connector types. Extensible via the registry — any string name works. */
+export enum ConnectorType {
+  // Source control providers
+  GitHub = 'github',
+  GitLab = 'gitlab',
+  Bitbucket = 'bitbucket',
+
+  // Project management providers
+  Jira = 'jira',
+  Monday = 'monday',
+  Linear = 'linear',
+}
+
+// ── Connector Config ────────────────────────────────────────────────────────
+
+/** Base configuration every connector receives. */
+export interface ConnectorConfig {
+  /** The connector name (must match the registered name). */
+  name: string;
+  /** Provider-specific configuration (opaque to the registry). */
+  [key: string]: unknown;
+}
+
+// ── Connector Auth ──────────────────────────────────────────────────────────
+
+/** Authentication lifecycle for a connector. */
+export interface ConnectorAuth {
+  /** Run the interactive authentication flow (OAuth, device-flow, etc.). */
+  authenticate(): Promise<void>;
+  /** Refresh an expired token, if supported. */
+  refreshToken(): Promise<void>;
+  /** Whether valid credentials currently exist. */
+  isAuthenticated(): Promise<boolean>;
+  /** Return current tokens/credentials (opaque record). */
+  getTokens(): Record<string, string>;
+}
+
+// ── Source Control Connector ────────────────────────────────────────────────
+
+/** Options for creating a pull request. */
+export interface PRCreateOptions {
+  title: string;
+  body: string;
+  baseBranch: string;
+  headBranch: string;
+  draft?: boolean;
+  labels?: string[];
+  assignees?: string[];
+}
+
+/** Minimal pull request information returned by the connector. */
+export interface PRInfo {
+  number: number;
+  url: string;
+  title: string;
+  state: 'open' | 'closed' | 'merged';
+  headBranch: string;
+  baseBranch: string;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+}
+
+/** A review submitted on a pull request. */
+export interface PRReview {
+  state: 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED' | 'PENDING';
+  body: string;
+}
+
+/** Merge options for a pull request. */
+export interface PRMergeOptions {
+  method?: 'merge' | 'squash' | 'rebase';
+  deleteAfterMerge?: boolean;
+}
+
+/**
+ * Unified interface for source control providers (GitHub, GitLab, Bitbucket, …).
+ */
+export interface SourceControlConnector {
+  /** Human-readable display name (e.g. "GitHub"). */
+  readonly displayName: string;
+  /** Connector identifier matching registry key (e.g. "github"). */
+  readonly name: string;
+
+  /** Authentication lifecycle. */
+  auth: ConnectorAuth;
+
+  /** Create a pull/merge request. */
+  createPR(workDir: string, options: PRCreateOptions): Promise<{ number: number; url: string }>;
+  /** Fetch a pull request by number. */
+  getPR(workDir: string, prNumber: number): Promise<PRInfo>;
+  /** List pull requests. */
+  listPRs(workDir: string, state?: 'open' | 'closed' | 'all'): Promise<PRInfo[]>;
+  /** Merge a pull request. */
+  mergePR(workDir: string, prNumber: number, options?: PRMergeOptions): Promise<void>;
+  /** Add a comment to a pull request. */
+  commentOnPR(workDir: string, prNumber: number, body: string): Promise<void>;
+  /** Submit a review on a pull request. */
+  reviewPR(workDir: string, prNumber: number, review: PRReview): Promise<void>;
+}
+
+// ── Project Management Connector ────────────────────────────────────────────
+
+/** A generic issue/item from an external PM tool. */
+export interface ExternalIssue {
+  /** Provider-specific ID (e.g. Jira ID "10001"). */
+  id: string;
+  /** Provider-specific key (e.g. Jira key "PROJ-42"). */
+  key: string;
+  /** Issue summary/title. */
+  title: string;
+  /** Plain-text description (provider-specific markup stripped). */
+  description: string;
+  /** Current status name as it appears in the provider. */
+  status: string;
+  /** Issue type name (Story, Bug, Epic, Task, …). */
+  type: string;
+  /** Labels/tags. */
+  labels: string[];
+  /** Raw provider-specific data for advanced use. */
+  raw?: unknown;
+}
+
+/** A fetched epic/parent with its metadata. */
+export interface ExternalEpic {
+  key: string;
+  id: string;
+  title: string;
+  description: string;
+  raw?: unknown;
+}
+
+/** Options for searching issues. */
+export interface IssueSearchOptions {
+  query: string;
+  maxResults?: number;
+  fields?: string[];
+}
+
+/** Options for creating an issue. */
+export interface IssueCreateOptions {
+  projectKey: string;
+  title: string;
+  type: string;
+  description?: string;
+  labels?: string[];
+  parentKey?: string;
+  customFields?: Record<string, unknown>;
+}
+
+/** Options for updating an issue. */
+export interface IssueUpdateOptions {
+  title?: string;
+  description?: string;
+  labels?: string[];
+  customFields?: Record<string, unknown>;
+}
+
+/** Result from parsing an epic URL or key. */
+export interface ParsedEpicRef {
+  /** The issue key extracted (e.g. "PROJ-2"). */
+  issueKey: string;
+  /** The site/host URL (e.g. "https://mysite.atlassian.net"). */
+  siteUrl: string;
+}
+
+/**
+ * Unified interface for project management providers (Jira, Monday, Linear, …).
+ */
+export interface ProjectManagementConnector {
+  /** Human-readable display name (e.g. "Jira"). */
+  readonly displayName: string;
+  /** Connector identifier matching registry key (e.g. "jira"). */
+  readonly name: string;
+
+  /** Authentication lifecycle. */
+  auth: ConnectorAuth;
+
+  /** Fetch a single issue by key or ID. */
+  fetchIssue(issueKeyOrId: string): Promise<ExternalIssue>;
+  /** Search for issues using a provider-specific query. */
+  searchIssues(options: IssueSearchOptions): Promise<ExternalIssue[]>;
+  /** Create a new issue/item. */
+  createIssue(options: IssueCreateOptions): Promise<{ id: string; key: string }>;
+  /** Update an existing issue. */
+  updateIssue(issueKeyOrId: string, options: IssueUpdateOptions): Promise<void>;
+  /** Transition an issue to a new status. */
+  transitionIssue(issueKeyOrId: string, targetStatus: string): Promise<boolean>;
+  /** Sync statuses bidirectionally (returns count of items updated). */
+  syncStatuses(statusMapping: Record<string, string>): Promise<number>;
+  /** Import an epic/parent item from the provider. */
+  importEpic(epicKeyOrUrl: string): Promise<ExternalEpic>;
+
+  /** Parse an epic URL or key into a structured reference. Returns null if unparseable. */
+  parseEpicRef(epicUrlOrKey: string): ParsedEpicRef | null;
+  /** Check whether a string looks like a valid epic URL/key for this provider. */
+  isEpicRef(value: string): boolean;
+}


### PR DESCRIPTION
## Summary
- Creates `src/connectors/types.ts` with `SourceControlConnector`,
  `ProjectManagementConnector`, `ConnectorAuth`, `ConnectorConfig`,
  and `ConnectorType` enum — foundational interfaces for CONN-001
- Creates `src/connectors/registry.ts` with singleton `ConnectorRegistry`
  supporting factory-based registration and `initializeFromConfig()`
- Adds 23 comprehensive tests covering interface contracts, registry
  lifecycle, error handling, and edge cases

## Story
CONN-001: Define Connector Abstraction Layer

## Test plan
- [x] All 23 new connector tests passing
- [x] Full test suite (1165 tests) passing
- [x] ESLint: 0 errors
- [x] TypeScript type-check: clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)