### PR TITLE
feat: implement GitHub source control and auth connectors

### DIFF
--- a/src/connectors/auth/github.test.ts
+++ b/src/connectors/auth/github.test.ts
@@ -1,0 +1,173 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { registry } from '../registry.js';
+import { GitHubAuthConnector, register } from './github.js';
+
+// Mock the underlying modules
+vi.mock('../../auth/github-oauth.js', () => ({
+  runGitHubDeviceFlow: vi.fn(),
+}));
+
+vi.mock('../../git/github.js', () => ({
+  isGitHubAuthenticated: vi.fn(),
+}));
+
+describe('GitHubAuthConnector', () => {
+  let connector: GitHubAuthConnector;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    connector = new GitHubAuthConnector();
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('should have provider set to "github"', () => {
+    expect(connector.provider).toBe('github');
+  });
+
+  it('should return "GitHub" from getProviderName', () => {
+    expect(connector.getProviderName()).toBe('GitHub');
+  });
+
+  describe('authenticate', () => {
+    it('should succeed with valid clientId option', async () => {
+      const { runGitHubDeviceFlow } = await import('../../auth/github-oauth.js');
+      vi.mocked(runGitHubDeviceFlow).mockResolvedValue({
+        token: 'ghp_test123',
+        username: 'testuser',
+      });
+
+      const result = await connector.authenticate({ clientId: 'test-client-id' });
+
+      expect(runGitHubDeviceFlow).toHaveBeenCalledWith({
+        clientId: 'test-client-id',
+        rootDir: undefined,
+      });
+      expect(result).toEqual({
+        success: true,
+        provider: 'github',
+        message: 'Authenticated as testuser',
+      });
+    });
+
+    it('should use GITHUB_CLIENT_ID from env when no option provided', async () => {
+      process.env.GITHUB_CLIENT_ID = 'env-client-id';
+
+      const { runGitHubDeviceFlow } = await import('../../auth/github-oauth.js');
+      vi.mocked(runGitHubDeviceFlow).mockResolvedValue({
+        token: 'ghp_test123',
+        username: 'envuser',
+      });
+
+      const result = await connector.authenticate();
+
+      expect(runGitHubDeviceFlow).toHaveBeenCalledWith({
+        clientId: 'env-client-id',
+        rootDir: undefined,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should pass rootDir option through', async () => {
+      const { runGitHubDeviceFlow } = await import('../../auth/github-oauth.js');
+      vi.mocked(runGitHubDeviceFlow).mockResolvedValue({
+        token: 'ghp_test123',
+        username: 'testuser',
+      });
+
+      await connector.authenticate({ clientId: 'cid', rootDir: '/my/project' });
+
+      expect(runGitHubDeviceFlow).toHaveBeenCalledWith({
+        clientId: 'cid',
+        rootDir: '/my/project',
+      });
+    });
+
+    it('should return failure when no clientId available', async () => {
+      delete process.env.GITHUB_CLIENT_ID;
+
+      const result = await connector.authenticate();
+
+      expect(result).toEqual({
+        success: false,
+        provider: 'github',
+        message: 'GitHub Client ID is required. Set GITHUB_CLIENT_ID or pass clientId in options.',
+      });
+    });
+
+    it('should return failure on auth error', async () => {
+      const { runGitHubDeviceFlow } = await import('../../auth/github-oauth.js');
+      vi.mocked(runGitHubDeviceFlow).mockRejectedValue(new Error('Device code expired'));
+
+      const result = await connector.authenticate({ clientId: 'test-client-id' });
+
+      expect(result).toEqual({
+        success: false,
+        provider: 'github',
+        message: 'GitHub auth failed: Device code expired',
+      });
+    });
+  });
+
+  describe('validateCredentials', () => {
+    it('should return true when authenticated via token', async () => {
+      const { isGitHubAuthenticated } = await import('../../git/github.js');
+      vi.mocked(isGitHubAuthenticated).mockResolvedValue({
+        authenticated: true,
+        method: 'token',
+      });
+
+      const result = await connector.validateCredentials();
+      expect(result).toBe(true);
+    });
+
+    it('should return true when authenticated via gh CLI', async () => {
+      const { isGitHubAuthenticated } = await import('../../git/github.js');
+      vi.mocked(isGitHubAuthenticated).mockResolvedValue({
+        authenticated: true,
+        method: 'gh-cli',
+      });
+
+      const result = await connector.validateCredentials();
+      expect(result).toBe(true);
+    });
+
+    it('should return false when not authenticated', async () => {
+      const { isGitHubAuthenticated } = await import('../../git/github.js');
+      vi.mocked(isGitHubAuthenticated).mockResolvedValue({
+        authenticated: false,
+        method: 'none',
+      });
+
+      const result = await connector.validateCredentials();
+      expect(result).toBe(false);
+    });
+  });
+});
+
+describe('register', () => {
+  afterEach(() => {
+    registry.reset();
+  });
+
+  it('should register the GitHub auth connector', () => {
+    register();
+
+    const connector = registry.getAuth('github');
+    expect(connector).toBeInstanceOf(GitHubAuthConnector);
+    expect(connector?.provider).toBe('github');
+  });
+
+  it('should lazily instantiate the connector', () => {
+    register();
+
+    const providers = registry.listAuthProviders();
+    expect(providers).toContain('github');
+  });
+});

--- a/src/connectors/auth/github.ts
+++ b/src/connectors/auth/github.ts
@@ -1,0 +1,64 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import type { ConnectorAuthResult } from '../common-types.js';
+import { registry } from '../registry.js';
+import type { IAuthConnector } from './types.js';
+
+/**
+ * GitHub implementation of IAuthConnector.
+ *
+ * Thin adapter that delegates to the existing GitHub Device Flow
+ * implementation in `src/auth/github-oauth.ts`.
+ */
+export class GitHubAuthConnector implements IAuthConnector {
+  readonly provider = 'github';
+
+  async authenticate(options?: Record<string, unknown>): Promise<ConnectorAuthResult> {
+    const { runGitHubDeviceFlow } = await import('../../auth/github-oauth.js');
+
+    const clientId = (options?.clientId as string) || process.env.GITHUB_CLIENT_ID || '';
+    const rootDir = (options?.rootDir as string) || undefined;
+
+    if (!clientId) {
+      return {
+        success: false,
+        provider: this.provider,
+        message: 'GitHub Client ID is required. Set GITHUB_CLIENT_ID or pass clientId in options.',
+      };
+    }
+
+    try {
+      const result = await runGitHubDeviceFlow({ clientId, rootDir });
+      return {
+        success: true,
+        provider: this.provider,
+        message: `Authenticated as ${result.username}`,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        provider: this.provider,
+        message: `GitHub auth failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  async validateCredentials(): Promise<boolean> {
+    const { isGitHubAuthenticated } = await import('../../git/github.js');
+    const status = await isGitHubAuthenticated();
+    return status.authenticated;
+  }
+
+  getProviderName(): string {
+    return 'GitHub';
+  }
+}
+
+/**
+ * Register the GitHub auth connector with the global registry.
+ * Call this once at startup to make the connector available via
+ * `registry.getAuth('github')`.
+ */
+export function register(): void {
+  registry.registerAuth('github', () => new GitHubAuthConnector());
+}

--- a/src/connectors/source-control/github.test.ts
+++ b/src/connectors/source-control/github.test.ts
@@ -1,0 +1,214 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { registry } from '../registry.js';
+import { GitHubSourceControlConnector, register } from './github.js';
+
+// Mock the underlying github.ts module
+vi.mock('../../git/github.js', () => ({
+  createPullRequest: vi.fn(),
+  mergePullRequest: vi.fn(),
+  listPullRequests: vi.fn(),
+  getPullRequestDiff: vi.fn(),
+  commentOnPullRequest: vi.fn(),
+  getPullRequestReviews: vi.fn(),
+  reviewPullRequest: vi.fn(),
+}));
+
+describe('GitHubSourceControlConnector', () => {
+  let connector: GitHubSourceControlConnector;
+
+  beforeEach(() => {
+    connector = new GitHubSourceControlConnector();
+    vi.clearAllMocks();
+  });
+
+  it('should have provider set to "github"', () => {
+    expect(connector.provider).toBe('github');
+  });
+
+  describe('createPullRequest', () => {
+    it('should delegate to github.createPullRequest', async () => {
+      const { createPullRequest } = await import('../../git/github.js');
+      vi.mocked(createPullRequest).mockResolvedValue({ number: 42, url: 'https://github.com/test/repo/pull/42' });
+
+      const result = await connector.createPullRequest('/work', {
+        title: 'feat: add feature',
+        body: 'Description',
+        baseBranch: 'main',
+        headBranch: 'feature/test',
+        draft: false,
+        labels: ['enhancement'],
+      });
+
+      expect(createPullRequest).toHaveBeenCalledWith('/work', {
+        title: 'feat: add feature',
+        body: 'Description',
+        baseBranch: 'main',
+        headBranch: 'feature/test',
+        draft: false,
+        labels: ['enhancement'],
+      });
+      expect(result).toEqual({ number: 42, url: 'https://github.com/test/repo/pull/42' });
+    });
+  });
+
+  describe('mergePullRequest', () => {
+    it('should delegate to github.mergePullRequest with options', async () => {
+      const { mergePullRequest } = await import('../../git/github.js');
+      vi.mocked(mergePullRequest).mockResolvedValue(undefined);
+
+      await connector.mergePullRequest('/work', 42, { method: 'squash', deleteAfterMerge: true });
+
+      expect(mergePullRequest).toHaveBeenCalledWith('/work', 42, {
+        method: 'squash',
+        deleteAfterMerge: true,
+      });
+    });
+
+    it('should handle undefined options', async () => {
+      const { mergePullRequest } = await import('../../git/github.js');
+      vi.mocked(mergePullRequest).mockResolvedValue(undefined);
+
+      await connector.mergePullRequest('/work', 42);
+
+      expect(mergePullRequest).toHaveBeenCalledWith('/work', 42, {
+        method: undefined,
+        deleteAfterMerge: undefined,
+      });
+    });
+  });
+
+  describe('listPullRequests', () => {
+    it('should delegate to github.listPullRequests', async () => {
+      const { listPullRequests } = await import('../../git/github.js');
+      const mockPRs = [
+        {
+          number: 1,
+          url: 'https://github.com/test/repo/pull/1',
+          title: 'PR 1',
+          state: 'open' as const,
+          headBranch: 'feature/a',
+          baseBranch: 'main',
+          additions: 10,
+          deletions: 5,
+          changedFiles: 2,
+        },
+      ];
+      vi.mocked(listPullRequests).mockResolvedValue(mockPRs);
+
+      const result = await connector.listPullRequests('/work', 'open');
+
+      expect(listPullRequests).toHaveBeenCalledWith('/work', 'open');
+      expect(result).toEqual(mockPRs);
+    });
+
+    it('should work without state parameter', async () => {
+      const { listPullRequests } = await import('../../git/github.js');
+      vi.mocked(listPullRequests).mockResolvedValue([]);
+
+      await connector.listPullRequests('/work');
+
+      expect(listPullRequests).toHaveBeenCalledWith('/work', undefined);
+    });
+  });
+
+  describe('getPullRequestDiff', () => {
+    it('should delegate to github.getPullRequestDiff', async () => {
+      const { getPullRequestDiff } = await import('../../git/github.js');
+      vi.mocked(getPullRequestDiff).mockResolvedValue('diff --git a/file.ts b/file.ts\n+added');
+
+      const result = await connector.getPullRequestDiff('/work', 42);
+
+      expect(getPullRequestDiff).toHaveBeenCalledWith('/work', 42);
+      expect(result).toBe('diff --git a/file.ts b/file.ts\n+added');
+    });
+  });
+
+  describe('addPRComment', () => {
+    it('should delegate to github.commentOnPullRequest', async () => {
+      const { commentOnPullRequest } = await import('../../git/github.js');
+      vi.mocked(commentOnPullRequest).mockResolvedValue(undefined);
+
+      await connector.addPRComment('/work', 42, 'LGTM!');
+
+      expect(commentOnPullRequest).toHaveBeenCalledWith('/work', 42, 'LGTM!');
+    });
+  });
+
+  describe('getPRReviews', () => {
+    it('should map review states to lowercase connector format', async () => {
+      const { getPullRequestReviews } = await import('../../git/github.js');
+      vi.mocked(getPullRequestReviews).mockResolvedValue([
+        { author: 'alice', state: 'APPROVED', body: 'Looks good' },
+        { author: 'bob', state: 'CHANGES_REQUESTED', body: 'Needs work' },
+        { author: 'charlie', state: 'COMMENTED', body: 'Question' },
+      ]);
+
+      const result = await connector.getPRReviews('/work', 42);
+
+      expect(getPullRequestReviews).toHaveBeenCalledWith('/work', 42);
+      expect(result).toEqual([
+        { author: 'alice', state: 'approved', body: 'Looks good' },
+        { author: 'bob', state: 'changes_requested', body: 'Needs work' },
+        { author: 'charlie', state: 'commented', body: 'Question' },
+      ]);
+    });
+
+    it('should return empty array when no reviews', async () => {
+      const { getPullRequestReviews } = await import('../../git/github.js');
+      vi.mocked(getPullRequestReviews).mockResolvedValue([]);
+
+      const result = await connector.getPRReviews('/work', 42);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('approvePullRequest', () => {
+    it('should delegate to github.reviewPullRequest with APPROVED state', async () => {
+      const { reviewPullRequest } = await import('../../git/github.js');
+      vi.mocked(reviewPullRequest).mockResolvedValue(undefined);
+
+      await connector.approvePullRequest('/work', 42, 'Ship it!');
+
+      expect(reviewPullRequest).toHaveBeenCalledWith('/work', 42, {
+        state: 'APPROVED',
+        body: 'Ship it!',
+      });
+    });
+
+    it('should use empty string body when none provided', async () => {
+      const { reviewPullRequest } = await import('../../git/github.js');
+      vi.mocked(reviewPullRequest).mockResolvedValue(undefined);
+
+      await connector.approvePullRequest('/work', 42);
+
+      expect(reviewPullRequest).toHaveBeenCalledWith('/work', 42, {
+        state: 'APPROVED',
+        body: '',
+      });
+    });
+  });
+});
+
+describe('register', () => {
+  afterEach(() => {
+    registry.reset();
+  });
+
+  it('should register the GitHub source control connector', () => {
+    register();
+
+    const connector = registry.getSourceControl('github');
+    expect(connector).toBeInstanceOf(GitHubSourceControlConnector);
+    expect(connector?.provider).toBe('github');
+  });
+
+  it('should lazily instantiate the connector', () => {
+    register();
+
+    // Registry should have the factory registered
+    const providers = registry.listSourceControlProviders();
+    expect(providers).toContain('github');
+  });
+});

--- a/src/connectors/source-control/github.ts
+++ b/src/connectors/source-control/github.ts
@@ -1,0 +1,79 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import type {
+  ConnectorPRInfo,
+  ConnectorPRResult,
+  ConnectorPRReview,
+  CreatePROptions,
+  MergePROptions,
+} from '../common-types.js';
+import { registry } from '../registry.js';
+import type { ISourceControlConnector } from './types.js';
+
+/**
+ * GitHub implementation of ISourceControlConnector.
+ *
+ * Thin adapter that delegates to the existing `src/git/github.ts` utilities.
+ * All PR operations go through the `gh` CLI under the hood.
+ */
+export class GitHubSourceControlConnector implements ISourceControlConnector {
+  readonly provider = 'github';
+
+  async createPullRequest(workDir: string, options: CreatePROptions): Promise<ConnectorPRResult> {
+    const { createPullRequest } = await import('../../git/github.js');
+    return createPullRequest(workDir, options);
+  }
+
+  async mergePullRequest(workDir: string, prNumber: number, options?: MergePROptions): Promise<void> {
+    const { mergePullRequest } = await import('../../git/github.js');
+    await mergePullRequest(workDir, prNumber, {
+      method: options?.method,
+      deleteAfterMerge: options?.deleteAfterMerge,
+    });
+  }
+
+  async listPullRequests(
+    workDir: string,
+    state?: 'open' | 'closed' | 'all'
+  ): Promise<ConnectorPRInfo[]> {
+    const { listPullRequests } = await import('../../git/github.js');
+    return listPullRequests(workDir, state);
+  }
+
+  async getPullRequestDiff(workDir: string, prNumber: number): Promise<string> {
+    const { getPullRequestDiff } = await import('../../git/github.js');
+    return getPullRequestDiff(workDir, prNumber);
+  }
+
+  async addPRComment(workDir: string, prNumber: number, body: string): Promise<void> {
+    const { commentOnPullRequest } = await import('../../git/github.js');
+    await commentOnPullRequest(workDir, prNumber, body);
+  }
+
+  async getPRReviews(workDir: string, prNumber: number): Promise<ConnectorPRReview[]> {
+    const { getPullRequestReviews } = await import('../../git/github.js');
+    const reviews = await getPullRequestReviews(workDir, prNumber);
+    return reviews.map(r => ({
+      author: r.author,
+      state: r.state.toLowerCase() as ConnectorPRReview['state'],
+      body: r.body,
+    }));
+  }
+
+  async approvePullRequest(workDir: string, prNumber: number, body?: string): Promise<void> {
+    const { reviewPullRequest } = await import('../../git/github.js');
+    await reviewPullRequest(workDir, prNumber, {
+      state: 'APPROVED',
+      body: body ?? '',
+    });
+  }
+}
+
+/**
+ * Register the GitHub source control connector with the global registry.
+ * Call this once at startup to make the connector available via
+ * `registry.getSourceControl('github')`.
+ */
+export function register(): void {
+  registry.registerSourceControl('github', () => new GitHubSourceControlConnector());
+}


### PR DESCRIPTION
## Summary
- Implements `GitHubSourceControlConnector` (`src/connectors/source-control/github.ts`) wrapping existing `src/git/github.ts` PR operations behind the `ISourceControlConnector` interface
- Implements `GitHubAuthConnector` (`src/connectors/auth/github.ts`) wrapping existing `src/auth/github-oauth.ts` device flow behind the `IAuthConnector` interface
- Both connectors export `register()` functions for self-registration with the connector registry
- 26 new tests covering all connector methods, edge cases, and registry integration

## Story
[CONN-002] Implement GitHub source control connector

## Design Decisions
- **Thin adapter pattern**: Connectors delegate to existing modules via dynamic `import()`, keeping the adapter layer minimal and avoiding circular dependencies
- **Review state normalization**: GitHub returns uppercase review states (`APPROVED`); the connector normalizes to lowercase (`approved`) per the `ConnectorPRReview` type contract
- **Auth connector**: Validates credentials using `isGitHubAuthenticated()` which checks both `GITHUB_TOKEN` env var and `gh` CLI auth status

## Test plan
- [x] All 26 new unit tests pass
- [x] Full test suite passes (1208 tests, 69 files)
- [x] Lint passes (0 errors)
- [x] Type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)