### PR TITLE
feat: make auth command provider-agnostic

### DIFF
--- a/src/auth/connector.ts
+++ b/src/auth/connector.ts
@@ -1,0 +1,28 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+/**
+ * Common result type for authentication flows
+ */
+export interface AuthResult {
+  provider: string;
+  success: boolean;
+  message?: string;
+}
+
+/**
+ * Interface for authentication connectors
+ * Each provider (GitHub, Jira, etc.) implements this interface
+ */
+export interface IAuthConnector {
+  /**
+   * The provider name (e.g., "github", "jira")
+   */
+  readonly name: string;
+
+  /**
+   * Run the authentication flow for this provider
+   * @param rootDir - The hive root directory for storing credentials
+   * @returns Promise resolving to the auth result
+   */
+  run(rootDir: string): Promise<AuthResult>;
+}

--- a/src/auth/connectors/github.ts
+++ b/src/auth/connectors/github.ts
@@ -1,0 +1,51 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import chalk from 'chalk';
+import type { AuthResult, IAuthConnector } from '../connector.js';
+import { runGitHubDeviceFlow } from '../github-oauth.js';
+
+/**
+ * GitHub authentication connector
+ */
+export class GitHubAuthConnector implements IAuthConnector {
+  readonly name = 'github';
+
+  async run(rootDir: string): Promise<AuthResult> {
+    try {
+      const clientId = process.env.GITHUB_OAUTH_CLIENT_ID;
+      if (!clientId) {
+        return {
+          provider: this.name,
+          success: false,
+          message: 'GITHUB_OAUTH_CLIENT_ID environment variable is not set',
+        };
+      }
+
+      console.log(chalk.bold('Starting GitHub OAuth Device Flow...'));
+      console.log();
+
+      const result = await runGitHubDeviceFlow({
+        clientId,
+        rootDir,
+      });
+
+      console.log();
+      console.log(chalk.green('✓ GitHub authentication successful!'));
+      console.log(chalk.gray(`User: ${result.username}`));
+      console.log(chalk.gray('Token saved to .env'));
+
+      return {
+        provider: this.name,
+        success: true,
+        message: `Authenticated as ${result.username}`,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        provider: this.name,
+        success: false,
+        message,
+      };
+    }
+  }
+}

--- a/src/auth/connectors/jira.ts
+++ b/src/auth/connectors/jira.ts
@@ -1,0 +1,83 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import { input } from '@inquirer/prompts';
+import chalk from 'chalk';
+import type { AuthResult, IAuthConnector } from '../connector.js';
+import { getEnvFilePath, loadEnvIntoProcess, readEnvFile, writeEnvEntries } from '../env-store.js';
+import { startJiraOAuthFlow, storeJiraTokens } from '../jira-oauth.js';
+import { TokenStore } from '../token-store.js';
+import { openBrowser } from '../../utils/open-browser.js';
+
+/**
+ * Jira authentication connector
+ */
+export class JiraAuthConnector implements IAuthConnector {
+  readonly name = 'jira';
+
+  async run(rootDir: string): Promise<AuthResult> {
+    try {
+      // Load stored credentials from .hive/.env, then check env vars, then prompt
+      loadEnvIntoProcess(rootDir);
+      const storedEnv = readEnvFile(rootDir);
+
+      const clientId =
+        process.env.JIRA_OAUTH_CLIENT_ID ||
+        storedEnv.JIRA_CLIENT_ID ||
+        (await input({
+          message: 'Jira OAuth Client ID',
+          validate: (v: string) => (v.length > 0 ? true : 'Client ID is required'),
+        }));
+
+      const clientSecret =
+        process.env.JIRA_OAUTH_CLIENT_SECRET ||
+        storedEnv.JIRA_CLIENT_SECRET ||
+        (await input({
+          message: 'Jira OAuth Client Secret',
+          validate: (v: string) => (v.length > 0 ? true : 'Client Secret is required'),
+        }));
+
+      console.log(chalk.bold('Starting Jira OAuth 2.0 (3LO) Flow...'));
+      console.log();
+
+      const result = await startJiraOAuthFlow({
+        clientId,
+        clientSecret,
+        openBrowser,
+      });
+
+      // Store tokens using TokenStore
+      const envPath = getEnvFilePath(rootDir);
+      const tokenStore = new TokenStore(envPath);
+      await tokenStore.loadFromEnv(envPath);
+      await storeJiraTokens(tokenStore, result);
+
+      // Also persist client credentials so token refresh works in future sessions
+      writeEnvEntries(
+        {
+          JIRA_CLIENT_ID: clientId,
+          JIRA_CLIENT_SECRET: clientSecret,
+        },
+        rootDir
+      );
+
+      console.log();
+      console.log(chalk.green('✓ Jira authentication successful!'));
+      console.log(chalk.gray(`Cloud ID: ${result.cloudId}`));
+      console.log(chalk.gray(`Site URL: ${result.siteUrl}`));
+      console.log(chalk.gray('Tokens saved to .env'));
+
+      return {
+        provider: this.name,
+        success: true,
+        message: `Authenticated with ${result.siteUrl}`,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        provider: this.name,
+        success: false,
+        message,
+      };
+    }
+  }
+}

--- a/src/auth/registry.ts
+++ b/src/auth/registry.ts
@@ -1,0 +1,49 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import type { IAuthConnector } from './connector.js';
+import { GitHubAuthConnector } from './connectors/github.js';
+import { JiraAuthConnector } from './connectors/jira.js';
+
+/**
+ * Registry of authentication connectors
+ */
+class AuthConnectorRegistry {
+  private connectors = new Map<string, IAuthConnector>();
+
+  constructor() {
+    // Register built-in connectors
+    this.register(new GitHubAuthConnector());
+    this.register(new JiraAuthConnector());
+  }
+
+  /**
+   * Register an auth connector
+   */
+  register(connector: IAuthConnector): void {
+    this.connectors.set(connector.name, connector);
+  }
+
+  /**
+   * Get an auth connector by provider name
+   */
+  get(providerName: string): IAuthConnector | undefined {
+    return this.connectors.get(providerName);
+  }
+
+  /**
+   * Get all registered connector names
+   */
+  getProviderNames(): string[] {
+    return Array.from(this.connectors.keys());
+  }
+
+  /**
+   * Check if a provider is registered
+   */
+  has(providerName: string): boolean {
+    return this.connectors.has(providerName);
+  }
+}
+
+// Singleton instance
+export const authRegistry = new AuthConnectorRegistry();

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -3,14 +3,115 @@
 import { input } from '@inquirer/prompts';
 import chalk from 'chalk';
 import { Command } from 'commander';
+import { authRegistry } from '../../auth/registry.js';
 import { getEnvFilePath, loadEnvIntoProcess, readEnvFile } from '../../auth/env-store.js';
 import { runGitHubDeviceFlow } from '../../auth/github-oauth.js';
 import { startJiraOAuthFlow, storeJiraTokens } from '../../auth/jira-oauth.js';
 import { TokenStore } from '../../auth/token-store.js';
+import { loadConfig } from '../../config/loader.js';
 import { openBrowser } from '../../utils/open-browser.js';
 import { withHiveRoot } from '../../utils/with-hive-context.js';
 
-export const authCommand = new Command('auth').description('Manage OAuth authentication');
+export const authCommand = new Command('auth')
+  .description('Manage OAuth authentication')
+  .option('--provider <name>', 'Authenticate a specific provider')
+  .action(async (options: { provider?: string }) => {
+    try {
+      const { paths } = withHiveRoot(ctx => ctx);
+
+      // If --provider flag is specified, authenticate that provider only
+      if (options.provider) {
+        const connector = authRegistry.get(options.provider);
+        if (!connector) {
+          console.error(chalk.red(`Error: Unknown provider "${options.provider}"`));
+          console.error(chalk.gray(`Available providers: ${authRegistry.getProviderNames().join(', ')}`));
+          process.exit(1);
+        }
+
+        const result = await connector.run(paths.hiveDir);
+        if (!result.success) {
+          console.error(chalk.red(`${connector.name} authentication failed:`));
+          console.error(chalk.gray(result.message || 'Unknown error'));
+          process.exit(1);
+        }
+        return;
+      }
+
+      // No --provider flag: authenticate all configured providers
+      const config = loadConfig(paths.hiveDir);
+      const providersToAuth: string[] = [];
+
+      // Check source control provider
+      if (config.integrations.source_control.provider) {
+        providersToAuth.push(config.integrations.source_control.provider);
+      }
+
+      // Check project management provider
+      if (config.integrations.project_management.provider !== 'none') {
+        providersToAuth.push(config.integrations.project_management.provider);
+      }
+
+      if (providersToAuth.length === 0) {
+        console.log(chalk.yellow('No providers configured. Nothing to authenticate.'));
+        console.log(chalk.gray('Run "hive config" to configure integrations.'));
+        return;
+      }
+
+      console.log(chalk.bold(`Authenticating ${providersToAuth.length} configured provider(s)...\n`));
+
+      const results: Array<{ provider: string; success: boolean; message?: string }> = [];
+
+      for (const providerName of providersToAuth) {
+        const connector = authRegistry.get(providerName);
+        if (!connector) {
+          console.error(chalk.yellow(`Warning: No auth connector found for "${providerName}". Skipping.`));
+          results.push({
+            provider: providerName,
+            success: false,
+            message: 'No auth connector found',
+          });
+          continue;
+        }
+
+        const result = await connector.run(paths.hiveDir);
+        results.push(result);
+
+        if (!result.success) {
+          console.error(chalk.red(`${connector.name} authentication failed:`));
+          console.error(chalk.gray(result.message || 'Unknown error'));
+        }
+
+        console.log(); // Add spacing between providers
+      }
+
+      // Summary
+      console.log(chalk.bold('Authentication Summary:'));
+      const successCount = results.filter(r => r.success).length;
+      const failCount = results.length - successCount;
+
+      for (const result of results) {
+        const icon = result.success ? chalk.green('✓') : chalk.red('✗');
+        console.log(`  ${icon} ${result.provider}: ${result.success ? 'success' : 'failed'}`);
+      }
+
+      if (failCount > 0) {
+        console.log();
+        console.log(chalk.red(`${failCount} provider(s) failed to authenticate.`));
+        process.exit(1);
+      }
+
+      console.log();
+      console.log(chalk.green(`All ${successCount} provider(s) authenticated successfully!`));
+    } catch (err) {
+      console.error(chalk.red('Authentication failed:'));
+      if (err instanceof Error) {
+        console.error(chalk.gray(err.message));
+      } else {
+        console.error(chalk.gray(String(err)));
+      }
+      process.exit(1);
+    }
+  });
 
 // GitHub OAuth subcommand
 authCommand


### PR DESCRIPTION
## Story: CONN-004

Refactored the auth CLI command to support config-driven authentication instead of requiring explicit `hive auth github` or `hive auth jira`.

### Changes

**New Features:**
- `hive auth` (no args) now authenticates against all configured providers from config
- `hive auth --provider <name>` authenticates a specific provider
- Backwards compatible: `hive auth github` and `hive auth jira` still work

**Implementation:**
- Created `IAuthConnector` interface to abstract auth flows
- Implemented `GitHubAuthConnector` and `JiraAuthConnector` wrapping existing OAuth flows
- Created auth connector registry mapping provider names to connectors
- Auth command now reads `integrations.source_control.provider` and `integrations.project_management.provider` from config
- Runs each configured provider's auth flow sequentially
- Reports success/failure per provider with summary

**Files Created:**
- `src/auth/connector.ts` - IAuthConnector interface
- `src/auth/registry.ts` - Auth connector registry
- `src/auth/connectors/github.ts` - GitHub auth connector
- `src/auth/connectors/jira.ts` - Jira auth connector

**Files Modified:**
- `src/cli/commands/auth.ts` - Refactored to support config-driven auth
- `src/cli/commands/auth.test.ts` - Added tests for new functionality

### Test Plan
- [x] All 1160 tests passing
- [x] Auth command tests cover new functionality
- [x] Build successful
- [x] No merge conflicts with main

🤖 Generated with [Claude Code](https://claude.com/claude-code)