### PR TITLE
feat: add periodic Hive-to-Jira status push in sync loop

### DIFF
--- a/src/db/queries/logs.ts
+++ b/src/db/queries/logs.ts
@@ -62,6 +62,7 @@ export type EventType =
   | 'JIRA_EPIC_INGESTED'
   | 'JIRA_ASSIGNMENT_REPAIRED'
   | 'JIRA_ASSIGNMENT_REPAIR_FAILED'
+  | 'JIRA_STATUS_PUSHED'
   | 'APPROACH_POSTED';
 
 export interface CreateLogInput {


### PR DESCRIPTION
## Summary
- Adds `syncHiveStatusesToJira()` function that detects when Hive story status is ahead of Jira and pushes the status change via `transitionJiraIssue()`
- Only pushes forward transitions (never regresses Jira status)
- Wired into `syncFromJira()` in the manager daemon loop, running every 60s cycle
- Catches missed event-driven syncs (manual DB fixes, race conditions, missed callbacks)

## Test plan
- [x] All 1247 tests pass
- [x] TypeScript type check clean
- [x] ESLint clean (0 errors, 8 pre-existing warnings)
- [x] Test: returns 0 when no status mapping configured
- [x] Test: returns 0 when no stories have Jira keys
- [x] Test: pushes Hive status to Jira when Hive is ahead
- [x] Test: skips when statuses match
- [x] Test: skips when Jira is ahead (no backward push)
- [x] Test: handles API errors gracefully
- [x] Test: skips draft stories
- [x] Test: pushes merged status to Jira

Story: CONN-013

🤖 Generated with [Claude Code](https://claude.com/claude-code)