### PR TITLE
fix: generalize extractStoryIdFromBranch to support non-STORY prefixes

### DIFF
--- a/src/utils/story-id.test.ts
+++ b/src/utils/story-id.test.ts
@@ -10,23 +10,35 @@ import {
 
 describe('Story ID utilities', () => {
   describe('STORY_ID_PATTERN', () => {
-    it('should match valid story IDs', () => {
+    it('should match valid story IDs with STORY prefix', () => {
       expect('STORY-001'.match(STORY_ID_PATTERN)).not.toBeNull();
       expect('STORY-FIX-004'.match(STORY_ID_PATTERN)).not.toBeNull();
       expect('STORY-REF-022'.match(STORY_ID_PATTERN)).not.toBeNull();
       expect('STORY-ABC123XYZ'.match(STORY_ID_PATTERN)).not.toBeNull();
     });
+
+    it('should match story IDs with non-STORY prefixes', () => {
+      expect('CONN-003'.match(STORY_ID_PATTERN)).not.toBeNull();
+      expect('HT-001'.match(STORY_ID_PATTERN)).not.toBeNull();
+      expect('INFRA-042'.match(STORY_ID_PATTERN)).not.toBeNull();
+    });
   });
 
   describe('isValidStoryId', () => {
-    it('should validate story IDs correctly', () => {
+    it('should validate STORY- IDs correctly', () => {
       expect(isValidStoryId('STORY-001')).toBe(true);
       expect(isValidStoryId('STORY-FIX-004')).toBe(true);
       expect(isValidStoryId('STORY-REF-022')).toBe(true);
     });
 
+    it('should validate non-STORY prefix IDs', () => {
+      expect(isValidStoryId('CONN-003')).toBe(true);
+      expect(isValidStoryId('HT-001')).toBe(true);
+      expect(isValidStoryId('INFRA-042')).toBe(true);
+    });
+
     it('should reject invalid story IDs', () => {
-      expect(isValidStoryId('INVALID-001')).toBe(false);
+      expect(isValidStoryId('A-001')).toBe(false); // prefix too short
       expect(isValidStoryId('')).toBe(false);
       expect(isValidStoryId(null)).toBe(false);
       expect(isValidStoryId(undefined)).toBe(false);
@@ -34,19 +46,27 @@ describe('Story ID utilities', () => {
   });
 
   describe('extractStoryIdFromBranch', () => {
-    it('should extract story ID from feature branch with prefix', () => {
+    it('should extract story ID from feature branch with STORY prefix', () => {
       expect(extractStoryIdFromBranch('feature/STORY-001-test')).toBe('STORY-001');
       expect(extractStoryIdFromBranch('feature/STORY-FIX-004-description')).toBe('STORY-FIX-004');
     });
 
-    it('should extract story ID from branch names with different prefixes', () => {
-      expect(extractStoryIdFromBranch('bugfix/STORY-REF-022-fix')).toBe('STORY-REF-022');
-      expect(extractStoryIdFromBranch('hotfix/STORY-IMP-003-critical')).toBe('STORY-IMP-003');
+    it('should extract non-STORY prefix IDs from branch names', () => {
+      expect(extractStoryIdFromBranch('feature/CONN-003-jira-pm-connector')).toBe('CONN-003');
+      expect(extractStoryIdFromBranch('feature/HT-001-add-feature')).toBe('HT-001');
+      expect(extractStoryIdFromBranch('feature/INFRA-042-fix-deploy')).toBe('INFRA-042');
     });
 
-    it('should extract story ID from branch names without prefix', () => {
+    it('should extract story ID from branch names with different git prefixes', () => {
+      expect(extractStoryIdFromBranch('bugfix/STORY-REF-022-fix')).toBe('STORY-REF-022');
+      expect(extractStoryIdFromBranch('hotfix/STORY-IMP-003-critical')).toBe('STORY-IMP-003');
+      expect(extractStoryIdFromBranch('bugfix/CONN-009-fix-sync')).toBe('CONN-009');
+    });
+
+    it('should extract story ID from branch names without git prefix', () => {
       expect(extractStoryIdFromBranch('STORY-001')).toBe('STORY-001');
       expect(extractStoryIdFromBranch('STORY-FIX-004')).toBe('STORY-FIX-004');
+      expect(extractStoryIdFromBranch('CONN-003')).toBe('CONN-003');
     });
 
     it('should extract story ID with dashes in description', () => {
@@ -63,7 +83,7 @@ describe('Story ID utilities', () => {
       expect(extractStoryIdFromBranch('develop')).toBeNull();
     });
 
-    it('should be case-insensitive', () => {
+    it('should be case-insensitive for STORY prefix (legacy support)', () => {
       expect(extractStoryIdFromBranch('feature/story-001-test')).toBe('STORY-001');
       expect(extractStoryIdFromBranch('feature/Story-FIX-004-description')).toBe('STORY-FIX-004');
     });


### PR DESCRIPTION
## Summary
- Generalizes `STORY_ID_PATTERN` to match any 2+ uppercase letter prefix (CONN-, HT-, INFRA-) instead of only STORY-
- Adds legacy case-insensitive STORY- fallback pattern for backward compatibility
- Updates `isValidStoryId` to accept any valid prefix format
- Fixes `syncMergedPRsFromGitHub()` failing to match branches like `feature/CONN-003-description`

## Test plan
- [x] All 1250 tests pass
- [x] TypeScript type check clean
- [x] ESLint clean
- [x] Test: CONN-003, HT-001, INFRA-042 extracted from branches
- [x] Test: Legacy story-001 lowercase still works (backward compat)
- [x] Test: Regular branches like feature/some-branch return null

Story: CONN-012

🤖 Generated with [Claude Code](https://claude.com/claude-code)