### PR TITLE
refactor: split orchestrator/scheduler.ts into focused modules

### DIFF
--- a/src/orchestrator/agent-selector.ts
+++ b/src/orchestrator/agent-selector.ts
@@ -1,0 +1,40 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import type { Database } from 'sql.js';
+import { queryOne } from '../db/client.js';
+import type { AgentRow } from '../db/queries/agents.js';
+
+/**
+ * Select the agent with the least workload (queue-depth aware).
+ * Returns the agent with fewest active stories; breaks ties by creation order.
+ */
+export function selectAgentWithLeastWorkload(db: Database, agents: AgentRow[]): AgentRow {
+  let selectedAgent = agents[0];
+  let minWorkload = getAgentWorkload(db, selectedAgent.id);
+
+  for (let i = 1; i < agents.length; i++) {
+    const workload = getAgentWorkload(db, agents[i].id);
+    if (workload < minWorkload) {
+      minWorkload = workload;
+      selectedAgent = agents[i];
+    }
+  }
+
+  return selectedAgent;
+}
+
+/**
+ * Calculate queue depth for an agent (number of active stories).
+ */
+export function getAgentWorkload(db: Database, agentId: string): number {
+  const result = queryOne<{ count: number }>(
+    db,
+    `
+    SELECT COUNT(*) as count FROM stories
+    WHERE assigned_agent_id = ?
+      AND status IN ('in_progress', 'review', 'qa', 'qa_failed')
+  `,
+    [agentId]
+  );
+  return result?.count || 0;
+}

--- a/src/orchestrator/capacity-planner.ts
+++ b/src/orchestrator/capacity-planner.ts
@@ -1,0 +1,75 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import type { ScalingConfig } from '../config/schema.js';
+import type { StoryRow } from '../db/queries/stories.js';
+
+/** Minimum refactor budget points when capacity is low */
+const MIN_REFACTOR_BUDGET_POINTS = 1;
+
+/**
+ * Convention-based story typing: refactor stories start with "Refactor:".
+ */
+export function isRefactorStory(story: StoryRow): boolean {
+  return /^refactor\s*:/i.test(story.title.trim());
+}
+
+/**
+ * Capacity computations prefer story points, then complexity score, then 1.
+ */
+export function getCapacityPoints(story: StoryRow): number {
+  return story.story_points || story.complexity_score || 1;
+}
+
+/**
+ * Apply configurable refactor-capacity policy before assignment.
+ */
+export function selectStoriesForCapacity(
+  stories: StoryRow[],
+  scalingConfig: ScalingConfig
+): StoryRow[] {
+  const refactorConfig = scalingConfig.refactor || {
+    enabled: false,
+    capacity_percent: 0,
+    allow_without_feature_work: false,
+  };
+
+  if (!refactorConfig.enabled) {
+    return stories.filter(story => !isRefactorStory(story));
+  }
+
+  const featureStories = stories.filter(story => !isRefactorStory(story));
+  const featurePoints = featureStories.reduce((sum, story) => sum + getCapacityPoints(story), 0);
+  const hasFeatureWork = featureStories.length > 0;
+
+  if (!hasFeatureWork && !refactorConfig.allow_without_feature_work) {
+    return [];
+  }
+
+  let refactorBudgetPoints = hasFeatureWork
+    ? Math.floor((featurePoints * refactorConfig.capacity_percent) / 100)
+    : Number.POSITIVE_INFINITY;
+
+  if (hasFeatureWork && refactorConfig.capacity_percent > 0 && refactorBudgetPoints === 0) {
+    refactorBudgetPoints = MIN_REFACTOR_BUDGET_POINTS;
+  }
+
+  let usedRefactorPoints = 0;
+  const selected: StoryRow[] = [];
+
+  for (const story of stories) {
+    if (!isRefactorStory(story)) {
+      selected.push(story);
+      continue;
+    }
+
+    const points = getCapacityPoints(story);
+    if (usedRefactorPoints + points > refactorBudgetPoints) {
+      continue;
+    }
+
+    selected.push(story);
+    usedRefactorPoints += points;
+  }
+
+  return selected;
+}

--- a/src/orchestrator/dependency-resolver.ts
+++ b/src/orchestrator/dependency-resolver.ts
@@ -1,0 +1,109 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import type { Database } from 'sql.js';
+import {
+  getBatchStoryDependencies,
+  getStoryDependencies,
+  type StoryRow,
+} from '../db/queries/stories.js';
+
+/**
+ * Build a dependency graph for stories.
+ * Returns a map of story ID to its direct dependencies.
+ */
+export function buildDependencyGraph(db: Database, stories: StoryRow[]): Map<string, Set<string>> {
+  const graph = new Map<string, Set<string>>();
+  const storyIds = new Set(stories.map(s => s.id));
+
+  // Initialize all stories in the graph
+  for (const story of stories) {
+    if (!graph.has(story.id)) {
+      graph.set(story.id, new Set());
+    }
+  }
+
+  // Fetch all dependencies in a single query to avoid N+1 pattern
+  const allDepsMap = getBatchStoryDependencies(db, Array.from(storyIds));
+
+  // Add dependencies (only within the planned set; external deps handled by areDependenciesSatisfied)
+  for (const [storyId, depIds] of allDepsMap) {
+    for (const depId of depIds) {
+      if (storyIds.has(depId)) {
+        graph.get(storyId)!.add(depId);
+      }
+    }
+  }
+
+  return graph;
+}
+
+/**
+ * Topological sort of stories based on dependencies.
+ * Returns stories in order where dependencies come before dependents.
+ * Returns null if circular dependency is detected.
+ */
+export function topologicalSort(db: Database, stories: StoryRow[]): StoryRow[] | null {
+  const graph = buildDependencyGraph(db, stories);
+  const storyMap = new Map(stories.map(s => [s.id, s]));
+
+  // Kahn's algorithm for topological sort
+  const inDegree = new Map<string, number>();
+  const result: StoryRow[] = [];
+
+  // Calculate in-degrees: count how many dependencies each story has
+  for (const [storyId, dependencies] of graph.entries()) {
+    inDegree.set(storyId, dependencies.size);
+  }
+
+  // Find all nodes with in-degree 0 (no dependencies)
+  const queue: string[] = [];
+  for (const [storyId, degree] of inDegree.entries()) {
+    if (degree === 0) {
+      queue.push(storyId);
+    }
+  }
+
+  // Process queue using Kahn's algorithm
+  while (queue.length > 0) {
+    const storyId = queue.shift()!;
+    const story = storyMap.get(storyId);
+    if (story) {
+      result.push(story);
+    }
+
+    // For each story that depends on this one, reduce in-degree
+    for (const [otherStoryId, dependencies] of graph.entries()) {
+      if (dependencies.has(storyId)) {
+        const newDegree = (inDegree.get(otherStoryId) || 0) - 1;
+        inDegree.set(otherStoryId, newDegree);
+        if (newDegree === 0) {
+          queue.push(otherStoryId);
+        }
+      }
+    }
+  }
+
+  // Check for circular dependencies
+  if (result.length !== stories.length) {
+    return null;
+  }
+
+  return result;
+}
+
+/**
+ * Check if a story's dependencies are satisfied.
+ * A dependency is satisfied only if it's merged (completed).
+ */
+export function areDependenciesSatisfied(db: Database, storyId: string): boolean {
+  const dependencies = getStoryDependencies(db, storyId);
+
+  for (const dep of dependencies) {
+    // Check if dependency is in a terminal state (merged)
+    if (dep.status !== 'merged') {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/orchestrator/orphan-recovery.ts
+++ b/src/orchestrator/orphan-recovery.ts
@@ -1,0 +1,41 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import type { Database } from 'sql.js';
+import { createLog } from '../db/queries/logs.js';
+import { getStoriesWithOrphanedAssignments, updateStory } from '../db/queries/stories.js';
+import { syncStatusToJira } from '../integrations/jira/transitions.js';
+
+/**
+ * Detect and recover orphaned stories (assigned to terminated agents).
+ * Returns the story IDs that were recovered.
+ */
+export function detectAndRecoverOrphanedStories(db: Database, rootDir: string): string[] {
+  const orphanedAssignments = getStoriesWithOrphanedAssignments(db);
+  const recovered: string[] = [];
+
+  for (const assignment of orphanedAssignments) {
+    try {
+      // Update story in single atomic operation
+      updateStory(db, assignment.id, {
+        assignedAgentId: null,
+        status: 'planned',
+      });
+      createLog(db, {
+        agentId: 'scheduler',
+        storyId: assignment.id,
+        eventType: 'ORPHANED_STORY_RECOVERED',
+        message: `Recovered from terminated agent ${assignment.agent_id}`,
+      });
+      recovered.push(assignment.id);
+
+      // Sync status change to Jira (fire and forget)
+      syncStatusToJira(rootDir, db, assignment.id, 'planned');
+    } catch (err) {
+      console.error(
+        `Failed to recover orphaned story ${assignment.id}: ${err instanceof Error ? err.message : 'Unknown error'}`
+      );
+    }
+  }
+
+  return recovered;
+}


### PR DESCRIPTION
## Summary
- Extract 9 private methods from the Scheduler class into 4 standalone, directly testable modules: `dependency-resolver.ts`, `capacity-planner.ts`, `agent-selector.ts`, and `orphan-recovery.ts`
- Update `scheduler.ts` to delegate to these new modules, keeping the public API unchanged
- Update test file to import functions directly, eliminating 52 `as any` casts (17 remain for methods that stay private on Scheduler)

## Test plan
- [x] All 1274 existing tests pass with no changes to test logic
- [x] TypeScript compiles with no errors (`npx tsc --noEmit`)
- [x] Prettier formatting verified on all new and modified files
- [x] No circular dependencies between new modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)