### PR TITLE
refactor: migrate direct Jira imports to connector pattern

### DIFF
--- a/src/cli/commands/manager/handoff-recovery.ts
+++ b/src/cli/commands/manager/handoff-recovery.ts
@@ -1,6 +1,7 @@
 // Licensed under the Hungry Ghost Hive License. See LICENSE.
 
 import chalk from 'chalk';
+import { syncStatusForStory } from '../../../connectors/project-management/operations.js';
 import type { DatabaseClient, StoryRow } from '../../../db/client.js';
 import { queryAll, withTransaction } from '../../../db/client.js';
 import { getTechLead } from '../../../db/queries/agents.js';
@@ -8,7 +9,6 @@ import { createEscalation } from '../../../db/queries/escalations.js';
 import { createLog } from '../../../db/queries/logs.js';
 import { updateRequirement } from '../../../db/queries/requirements.js';
 import { getStoriesByStatus, updateStory } from '../../../db/queries/stories.js';
-import { syncStatusToJira } from '../../../integrations/jira/transitions.js';
 import { isTmuxSessionRunning } from '../../../tmux/manager.js';
 import { nudgeAgent, type CLITool } from './agent-monitoring.js';
 import type { ManagerCheckContext, PlanningHandoffTracking } from './types.js';
@@ -131,7 +131,7 @@ async function promoteEstimatedStoriesToPlanned(
 
   // Sync status changes to Jira
   for (const story of stories) {
-    await syncStatusToJira(ctx.root, ctx.db.db, story.id, 'planned');
+    await syncStatusForStory(ctx.root, ctx.db.db, story.id, 'planned');
   }
 
   return promoted;

--- a/src/cli/commands/my-stories.ts
+++ b/src/cli/commands/my-stories.ts
@@ -2,10 +2,10 @@
 
 import chalk from 'chalk';
 import { Command } from 'commander';
+import { syncStatusForStory } from '../../connectors/project-management/operations.js';
 import { queryAll, queryOne, run, type StoryRow } from '../../db/client.js';
 import { createLog } from '../../db/queries/logs.js';
 import { createStory, getStoryDependencies, updateStory } from '../../db/queries/stories.js';
-import { syncStatusToJira } from '../../integrations/jira/transitions.js';
 import { withHiveContext, withReadOnlyHiveContext } from '../../utils/with-hive-context.js';
 
 export const myStoriesCommand = new Command('my-stories')
@@ -168,7 +168,7 @@ myStoriesCommand
       db.save();
 
       // Sync status change to Jira
-      await syncStatusToJira(root, db.db, storyId, 'in_progress');
+      await syncStatusForStory(root, db.db, storyId, 'in_progress');
 
       console.log(chalk.green(`Claimed story: ${storyId}`));
       console.log(chalk.gray(`Title: ${story.title}`));
@@ -198,7 +198,7 @@ myStoriesCommand
       db.save();
 
       // Sync status change to Jira
-      await syncStatusToJira(root, db.db, storyId, 'review');
+      await syncStatusForStory(root, db.db, storyId, 'review');
 
       console.log(chalk.green(`Story ${storyId} marked as ready for review.`));
     });

--- a/src/cli/commands/req.test.ts
+++ b/src/cli/commands/req.test.ts
@@ -15,6 +15,9 @@ function createMockPMConnector(provider: string): IProjectManagementConnector {
     searchIssues: vi.fn(),
     getIssue: vi.fn(),
     syncStatus: vi.fn(),
+    postComment: vi.fn(),
+    createSubtask: vi.fn(),
+    transitionSubtask: vi.fn(),
     isEpicUrl: vi.fn(),
     parseEpicUrl: vi.fn(),
   };

--- a/src/connectors/common-types.ts
+++ b/src/connectors/common-types.ts
@@ -137,6 +137,46 @@ export interface ConnectorSyncResult {
   errors: string[];
 }
 
+// ── Lifecycle Events ────────────────────────────────────────────────────
+
+/** Provider-agnostic lifecycle events that trigger comments */
+export type ConnectorLifecycleEvent =
+  | 'assigned'
+  | 'work_started'
+  | 'progress'
+  | 'approach_posted'
+  | 'pr_created'
+  | 'qa_started'
+  | 'qa_passed'
+  | 'qa_failed'
+  | 'merged'
+  | 'blocked';
+
+/** Context for posting lifecycle event comments */
+export interface ConnectorCommentContext {
+  agentName?: string;
+  branchName?: string;
+  prUrl?: string;
+  reason?: string;
+  subtaskKey?: string;
+  approachText?: string;
+}
+
+/** Options for creating a subtask */
+export interface ConnectorCreateSubtaskOptions {
+  parentIssueKey: string;
+  projectKey: string;
+  agentName: string;
+  storyTitle: string;
+  approachSteps?: string[];
+}
+
+/** Result from creating a subtask */
+export interface ConnectorSubtaskResult {
+  key: string;
+  id: string;
+}
+
 // ── Options ─────────────────────────────────────────────────────────────────
 
 /** Options for creating a pull request */

--- a/src/connectors/project-management/operation-queue.ts
+++ b/src/connectors/project-management/operation-queue.ts
@@ -1,0 +1,88 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import * as logger from '../../utils/logger.js';
+
+/**
+ * Represents a PM operation to be executed
+ */
+interface PMOperation {
+  id: string;
+  execute: () => Promise<void>;
+}
+
+/**
+ * Queue for serializing project management API operations to prevent race conditions.
+ *
+ * When multiple stories are assigned concurrently, PM operations (subtask creation,
+ * comments, status transitions) are queued and executed sequentially to avoid:
+ * - TokenStore file lock contention
+ * - API rate limiting
+ * - Concurrent token refresh issues
+ */
+export class PMOperationQueue {
+  private queue: PMOperation[] = [];
+  private processing = false;
+
+  /**
+   * Add a PM operation to the queue
+   * @param id - Unique identifier for logging (e.g., story ID)
+   * @param operation - Async function that performs the PM operation
+   */
+  enqueue(id: string, operation: () => Promise<void>): void {
+    this.queue.push({ id, execute: operation });
+
+    // Start processing if not already running
+    if (!this.processing) {
+      this.processQueue().catch(err => {
+        logger.error(
+          `PM operation queue processing failed: ${err instanceof Error ? err.message : String(err)}`
+        );
+      });
+    }
+  }
+
+  /**
+   * Process all queued operations sequentially
+   */
+  private async processQueue(): Promise<void> {
+    if (this.processing) {
+      return;
+    }
+
+    this.processing = true;
+
+    while (this.queue.length > 0) {
+      const operation = this.queue.shift();
+      if (!operation) continue;
+
+      try {
+        logger.debug(`Processing PM operation for ${operation.id}`);
+        await operation.execute();
+      } catch (err) {
+        // Log error but continue processing other operations
+        logger.warn(
+          `PM operation failed for ${operation.id}: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
+
+    this.processing = false;
+  }
+
+  /**
+   * Get the number of pending operations
+   */
+  size(): number {
+    return this.queue.length;
+  }
+
+  /**
+   * Wait for all queued operations to complete
+   * Useful for testing and ensuring operations complete before exiting
+   */
+  async waitForCompletion(): Promise<void> {
+    while (this.processing || this.queue.length > 0) {
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+  }
+}

--- a/src/connectors/project-management/operations.ts
+++ b/src/connectors/project-management/operations.ts
@@ -1,0 +1,352 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+/**
+ * Provider-agnostic high-level operations for project management.
+ *
+ * These functions replace direct Jira/provider imports in core modules.
+ * Each function loads config, resolves the active PM connector, and delegates
+ * to the appropriate provider implementation. All functions are safe to call
+ * even when no PM provider is configured — they silently return in that case.
+ */
+
+import { join } from 'path';
+import type { Database } from 'sql.js';
+import type { HiveConfig } from '../../config/schema.js';
+import { queryOne } from '../../db/client.js';
+import type { StoryRow } from '../../db/queries/stories.js';
+import * as logger from '../../utils/logger.js';
+import type {
+  ConnectorCommentContext,
+  ConnectorCreateSubtaskOptions,
+  ConnectorLifecycleEvent,
+  ConnectorSubtaskResult,
+} from '../common-types.js';
+import { registry } from '../registry.js';
+import type { IProjectManagementConnector } from './types.js';
+
+/**
+ * Ensure the PM connector for the given provider is registered and return it.
+ * Uses dynamic import to load the provider's registration module.
+ */
+async function getConnector(provider: string): Promise<IProjectManagementConnector | null> {
+  let connector = registry.getProjectManagement(provider);
+  if (connector) return connector;
+
+  // Lazily register the connector
+  if (provider === 'jira') {
+    const { register } = await import('./jira.js');
+    register();
+  }
+
+  connector = registry.getProjectManagement(provider);
+  return connector;
+}
+
+/**
+ * Load config and resolve the active PM provider.
+ * Returns null if no PM provider is configured.
+ */
+async function resolveProvider(root: string) {
+  const { loadConfig } = await import('../../config/loader.js');
+  const { getHivePaths } = await import('../../utils/paths.js');
+
+  const paths = getHivePaths(root);
+  const config = loadConfig(paths.hiveDir);
+  const pmConfig = config.integrations.project_management;
+
+  if (!pmConfig || pmConfig.provider === 'none') {
+    return null;
+  }
+
+  const connector = await getConnector(pmConfig.provider);
+  if (!connector) {
+    logger.debug(`No connector registered for PM provider "${pmConfig.provider}"`);
+    return null;
+  }
+
+  return { connector, config, paths, pmConfig };
+}
+
+/**
+ * Sync a story's status change to the PM provider.
+ * Replaces direct `syncStatusToJira()` calls.
+ *
+ * Never throws — failures are logged as debug messages.
+ */
+export async function syncStatusForStory(
+  root: string,
+  db: Database,
+  storyId: string,
+  newStatus: string
+): Promise<void> {
+  try {
+    // Delegate to the provider-specific sync function via dynamic import.
+    // This preserves the full logging and DB interaction logic in the integration module.
+    const resolved = await resolveProvider(root);
+    if (!resolved) return;
+
+    const { pmConfig } = resolved;
+
+    if (pmConfig.provider === 'jira') {
+      const { syncStatusToJira } = await import('../../integrations/jira/transitions.js');
+      await syncStatusToJira(root, db, storyId, newStatus);
+    }
+  } catch (err) {
+    logger.debug(
+      `Failed to sync status for story ${storyId}: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+
+/**
+ * Post a lifecycle comment on a story's PM issue.
+ * Replaces direct `postJiraLifecycleComment()` calls.
+ *
+ * Never throws — failures are logged as warnings.
+ */
+export async function postLifecycleComment(
+  db: Database,
+  _hiveDir: string,
+  hiveConfig: HiveConfig | undefined,
+  storyId: string,
+  event: ConnectorLifecycleEvent,
+  context: ConnectorCommentContext = {}
+): Promise<void> {
+  try {
+    if (!hiveConfig) return;
+    const pmConfig = hiveConfig.integrations?.project_management;
+    if (!pmConfig || pmConfig.provider === 'none') return;
+
+    const story = queryOne<StoryRow>(db, 'SELECT * FROM stories WHERE id = ?', [storyId]);
+    if (!story || !story.external_issue_key) {
+      logger.debug(`Story ${storyId} has no external issue key, skipping ${event} comment`);
+      return;
+    }
+
+    const connector = await getConnector(pmConfig.provider);
+    if (!connector) return;
+
+    await connector.postComment(story.external_issue_key, event, context);
+  } catch (err) {
+    logger.warn(
+      `Failed to post ${event} comment for story ${storyId}: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+
+/**
+ * Post a progress update to a story's subtask in the PM provider.
+ * Replaces direct `postProgressToSubtask()` calls.
+ *
+ * Never throws — failures are logged as warnings.
+ */
+export async function postProgressUpdate(
+  db: Database,
+  _hiveDir: string,
+  hiveConfig: HiveConfig | undefined,
+  storyId: string,
+  progressMessage: string,
+  agentName?: string
+): Promise<void> {
+  try {
+    if (!hiveConfig) return;
+    const pmConfig = hiveConfig.integrations?.project_management;
+    if (!pmConfig || pmConfig.provider === 'none') return;
+
+    const story = queryOne<StoryRow>(db, 'SELECT * FROM stories WHERE id = ?', [storyId]);
+    if (!story?.external_subtask_key) {
+      logger.debug(`Story ${storyId} has no external subtask, skipping progress update`);
+      return;
+    }
+
+    const connector = await getConnector(pmConfig.provider);
+    if (!connector) return;
+
+    await connector.postComment(story.external_subtask_key, 'progress', {
+      agentName,
+      reason: progressMessage,
+    });
+
+    await connector.transitionSubtask(story.external_subtask_key, 'In Progress');
+  } catch (err) {
+    logger.warn(
+      `Failed to post progress to subtask for story ${storyId}: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+
+/**
+ * Run bidirectional sync with the PM provider.
+ * Replaces direct `syncFromJira()` calls.
+ *
+ * Never throws — failures are logged.
+ */
+export async function syncFromProvider(root: string, db: Database): Promise<number> {
+  try {
+    const resolved = await resolveProvider(root);
+    if (!resolved) return 0;
+
+    const { pmConfig } = resolved;
+
+    if (pmConfig.provider === 'jira') {
+      const { syncFromJira } = await import('../../integrations/jira/sync.js');
+      return syncFromJira(root, db);
+    }
+
+    return 0;
+  } catch (err) {
+    logger.debug(
+      `Failed to sync from provider: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return 0;
+  }
+}
+
+/**
+ * Sync a single story to the PM provider.
+ * Replaces direct `syncStoryToJira()` calls.
+ */
+export async function syncStoryToProvider(
+  root: string,
+  db: Database,
+  story: StoryRow,
+  teamName?: string
+): Promise<{ key: string; id: string } | null> {
+  const resolved = await resolveProvider(root);
+  if (!resolved) return null;
+
+  const { pmConfig, paths } = resolved;
+
+  if (pmConfig.provider === 'jira' && pmConfig.jira) {
+    const { TokenStore } = await import('../../auth/token-store.js');
+    const { syncStoryToJira } = await import('../../integrations/jira/stories.js');
+
+    const envPath = join(paths.hiveDir, '.env');
+    const tokenStore = new TokenStore(envPath);
+    await tokenStore.loadFromEnv(envPath);
+
+    const result = await syncStoryToJira(db, tokenStore, pmConfig.jira, story, teamName);
+    if (!result) return null;
+    return { key: result.jiraKey, id: result.jiraId };
+  }
+
+  return null;
+}
+
+/**
+ * Sync a requirement and its stories to the PM provider.
+ * Replaces direct `syncRequirementToJira()` calls.
+ */
+export async function syncRequirementToProvider(
+  root: string,
+  db: Database,
+  requirement: { id: string; title: string; description: string },
+  storyIds: string[],
+  teamName?: string
+): Promise<{
+  epicKey: string | null;
+  stories: Array<{ storyId: string; key: string; id: string }>;
+  errors: string[];
+}> {
+  const emptyResult = { epicKey: null, stories: [], errors: [] };
+
+  const resolved = await resolveProvider(root);
+  if (!resolved) return emptyResult;
+
+  const { pmConfig, paths } = resolved;
+
+  if (pmConfig.provider === 'jira' && pmConfig.jira) {
+    const { TokenStore } = await import('../../auth/token-store.js');
+    const { syncRequirementToJira } = await import('../../integrations/jira/stories.js');
+
+    const envPath = join(paths.hiveDir, '.env');
+    const tokenStore = new TokenStore(envPath);
+    await tokenStore.loadFromEnv(envPath);
+
+    const result = await syncRequirementToJira(
+      db,
+      tokenStore,
+      pmConfig.jira,
+      requirement as any,
+      storyIds,
+      teamName
+    );
+
+    return {
+      epicKey: result.epicKey,
+      stories: result.stories.map(s => ({ storyId: s.storyId, key: s.jiraKey, id: s.jiraId })),
+      errors: result.errors,
+    };
+  }
+
+  return emptyResult;
+}
+
+/**
+ * Create a subtask for an assigned agent on a story's PM issue.
+ * Replaces direct JiraClient + createSubtask() calls.
+ *
+ * Never throws — returns null on failure.
+ */
+export async function createSubtaskForStory(
+  root: string,
+  _issueKey: string,
+  options: ConnectorCreateSubtaskOptions
+): Promise<ConnectorSubtaskResult | null> {
+  try {
+    const resolved = await resolveProvider(root);
+    if (!resolved) return null;
+
+    return resolved.connector.createSubtask(options);
+  } catch (err) {
+    logger.warn(
+      `Failed to create subtask for ${options.agentName}: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return null;
+  }
+}
+
+/**
+ * Post a comment on a PM issue.
+ * Replaces direct JiraClient + postComment() calls.
+ */
+export async function postCommentOnIssue(
+  root: string,
+  issueKey: string,
+  event: ConnectorLifecycleEvent,
+  context: ConnectorCommentContext = {}
+): Promise<boolean> {
+  try {
+    const resolved = await resolveProvider(root);
+    if (!resolved) return false;
+
+    return resolved.connector.postComment(issueKey, event, context);
+  } catch (err) {
+    logger.warn(
+      `Failed to post ${event} comment on ${issueKey}: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return false;
+  }
+}
+
+/**
+ * Transition a subtask to a target status.
+ * Replaces direct JiraClient + transitionSubtask() calls.
+ */
+export async function transitionSubtaskStatus(
+  root: string,
+  subtaskKey: string,
+  targetStatus: string
+): Promise<boolean> {
+  try {
+    const resolved = await resolveProvider(root);
+    if (!resolved) return false;
+
+    return resolved.connector.transitionSubtask(subtaskKey, targetStatus);
+  } catch (err) {
+    logger.warn(
+      `Failed to transition subtask ${subtaskKey}: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return false;
+  }
+}

--- a/src/connectors/project-management/types.ts
+++ b/src/connectors/project-management/types.ts
@@ -1,9 +1,13 @@
 // Licensed under the Hungry Ghost Hive License. See LICENSE.
 
 import type {
+  ConnectorCommentContext,
+  ConnectorCreateSubtaskOptions,
   ConnectorEpic,
   ConnectorIssue,
+  ConnectorLifecycleEvent,
   ConnectorParsedEpicUrl,
+  ConnectorSubtaskResult,
   CreateEpicOptions,
   CreateStoryOptions,
   SearchIssuesOptions,
@@ -75,6 +79,34 @@ export interface IProjectManagementConnector {
     hiveStatus: string,
     statusMapping: Record<string, string>
   ): Promise<boolean>;
+
+  /**
+   * Post a lifecycle event comment to an issue.
+   * @param issueKey - Issue key to comment on
+   * @param event - Lifecycle event type
+   * @param context - Additional context for the comment
+   * @returns true if successful, false otherwise
+   */
+  postComment(
+    issueKey: string,
+    event: ConnectorLifecycleEvent,
+    context?: ConnectorCommentContext
+  ): Promise<boolean>;
+
+  /**
+   * Create a subtask under a parent issue.
+   * @param options - Subtask creation options
+   * @returns Created subtask result, or null if failed
+   */
+  createSubtask(options: ConnectorCreateSubtaskOptions): Promise<ConnectorSubtaskResult | null>;
+
+  /**
+   * Transition a subtask to a target status.
+   * @param subtaskKey - Subtask key to transition
+   * @param targetStatus - Target status name
+   * @returns true if the transition was applied, false if skipped
+   */
+  transitionSubtask(subtaskKey: string, targetStatus: string): Promise<boolean>;
 
   /**
    * Check whether a string looks like an epic URL for this provider.

--- a/src/connectors/registry.test.ts
+++ b/src/connectors/registry.test.ts
@@ -31,6 +31,9 @@ function createMockProjectManagement(provider = 'jira'): IProjectManagementConne
     searchIssues: vi.fn(),
     getIssue: vi.fn(),
     syncStatus: vi.fn(),
+    postComment: vi.fn(),
+    createSubtask: vi.fn(),
+    transitionSubtask: vi.fn(),
     isEpicUrl: vi.fn(),
     parseEpicUrl: vi.fn(),
   };

--- a/src/orchestrator/orphan-recovery.ts
+++ b/src/orchestrator/orphan-recovery.ts
@@ -1,9 +1,9 @@
 // Licensed under the Hungry Ghost Hive License. See LICENSE.
 
 import type { Database } from 'sql.js';
+import { syncStatusForStory } from '../connectors/project-management/operations.js';
 import { createLog } from '../db/queries/logs.js';
 import { getStoriesWithOrphanedAssignments, updateStory } from '../db/queries/stories.js';
-import { syncStatusToJira } from '../integrations/jira/transitions.js';
 
 /**
  * Detect and recover orphaned stories (assigned to terminated agents).
@@ -29,7 +29,7 @@ export function detectAndRecoverOrphanedStories(db: Database, rootDir: string): 
       recovered.push(assignment.id);
 
       // Sync status change to Jira (fire and forget)
-      syncStatusToJira(rootDir, db, assignment.id, 'planned');
+      syncStatusForStory(rootDir, db, assignment.id, 'planned');
     } catch (err) {
       console.error(
         `Failed to recover orphaned story ${assignment.id}: ${err instanceof Error ? err.message : 'Unknown error'}`

--- a/src/utils/pr-sync.ts
+++ b/src/utils/pr-sync.ts
@@ -2,12 +2,12 @@
 
 import { execa } from 'execa';
 import type { Database } from 'sql.js';
+import { syncStatusForStory } from '../connectors/project-management/operations.js';
 import { queryAll, withTransaction } from '../db/client.js';
 import { createLog } from '../db/queries/logs.js';
 import { createPullRequest } from '../db/queries/pull-requests.js';
 import { updateStory } from '../db/queries/stories.js';
 import { getAllTeams } from '../db/queries/teams.js';
-import { syncStatusToJira } from '../integrations/jira/transitions.js';
 import { extractStoryIdFromBranch } from './story-id.js';
 
 const GITHUB_PR_LIST_LIMIT = 20;
@@ -277,7 +277,7 @@ export async function syncMergedPRsFromGitHub(
 
       // Sync status changes to Jira (fire and forget, after DB commit)
       for (const update of toUpdate) {
-        syncStatusToJira(root, db, update.storyId, 'merged');
+        syncStatusForStory(root, db, update.storyId, 'merged');
       }
 
       storiesUpdated += toUpdate.length;


### PR DESCRIPTION
## Summary
- Extend `IProjectManagementConnector` with `postComment`, `createSubtask`, `transitionSubtask` methods and add provider-agnostic DTOs to `common-types.ts`
- Create `src/connectors/project-management/operations.ts` with high-level provider-agnostic utility functions that replace direct Jira calls in core modules
- Create `PMOperationQueue` (provider-agnostic replacement for `JiraOperationQueue`) in the connectors layer
- Migrate 12 core modules from direct `integrations/jira/` imports to connector pattern imports

## Files migrated
`scheduler.ts`, `orphan-recovery.ts`, `manager/index.ts`, `handoff-recovery.ts`, `auto-merge.ts`, `pr-sync.ts`, `pr.ts`, `progress.ts`, `approach.ts`, `my-stories.ts`, `stories.ts`, `tech-lead.ts`

## Test plan
- [x] TypeScript compilation passes (0 errors)
- [x] All 1277 tests pass
- [x] Prettier formatting applied
- [x] No direct `integrations/jira/` imports remain in core modules (only in connector implementations and integration-layer test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)