### PR TITLE
fix(cli-runtimes): use danger-full-access for codex unsafe mode

### DIFF
--- a/src/cli-runtimes/codex.ts
+++ b/src/cli-runtimes/codex.ts
@@ -5,12 +5,13 @@ import { CliRuntimeBuilder, RuntimeSafetyMode } from './types.js';
 export class CodexRuntimeBuilder implements CliRuntimeBuilder {
   buildSpawnCommand(model: string, safetyMode: RuntimeSafetyMode): string[] {
     const approvalPolicy = safetyMode === 'safe' ? 'on-request' : 'never';
+    const sandboxMode = safetyMode === 'safe' ? 'workspace-write' : 'danger-full-access';
     return [
       'codex',
       '--ask-for-approval',
       approvalPolicy,
       '--sandbox',
-      'workspace-write',
+      sandboxMode,
       '--model',
       model,
     ];
@@ -18,13 +19,14 @@ export class CodexRuntimeBuilder implements CliRuntimeBuilder {
 
   buildResumeCommand(model: string, sessionId: string, safetyMode: RuntimeSafetyMode): string[] {
     const approvalPolicy = safetyMode === 'safe' ? 'on-request' : 'never';
+    const sandboxMode = safetyMode === 'safe' ? 'workspace-write' : 'danger-full-access';
     return [
       'codex',
       'resume',
       '--ask-for-approval',
       approvalPolicy,
       '--sandbox',
-      'workspace-write',
+      sandboxMode,
       '--model',
       model,
       sessionId,

--- a/src/cli-runtimes/index.test.ts
+++ b/src/cli-runtimes/index.test.ts
@@ -93,7 +93,7 @@ describe('CLI Runtime Builders', () => {
         '--ask-for-approval',
         'never',
         '--sandbox',
-        'workspace-write',
+        'danger-full-access',
         '--model',
         'gpt-4o-mini',
       ]);
@@ -124,7 +124,7 @@ describe('CLI Runtime Builders', () => {
         '--ask-for-approval',
         'never',
         '--sandbox',
-        'workspace-write',
+        'danger-full-access',
         '--model',
         'gpt-4o-mini',
         'session-456',


### PR DESCRIPTION
## Summary\n- change Codex runtime builder to use `--sandbox danger-full-access` when `safety_mode` is `unsafe`\n- keep `safe` mode on `--sandbox workspace-write`\n- update runtime builder tests accordingly\n\n## Validation\n- npm run build\n- npx vitest run src/cli-runtimes/index.test.ts\n\n## Notes\n- full `npm test` in this environment reports unrelated Jira test EPERM/listen sandbox failures