### PR TITLE
fix: avoid dashboard sql.js OOM on refresh

### DIFF
--- a/src/cli/dashboard/index.ts
+++ b/src/cli/dashboard/index.ts
@@ -4,7 +4,7 @@ import blessed from 'blessed';
 import { appendFileSync, existsSync, renameSync, statSync } from 'fs';
 import { join } from 'path';
 import type { Database } from 'sql.js';
-import { getDatabase, type DatabaseClient } from '../../db/client.js';
+import { getReadOnlyDatabase, type ReadOnlyDatabaseClient } from '../../db/client.js';
 import { getAllRequirements } from '../../db/queries/requirements.js';
 import { findHiveRoot, getHivePaths } from '../../utils/paths.js';
 import { getVersion } from '../../utils/version.js';
@@ -57,7 +57,7 @@ export async function startDashboard(options: DashboardOptions = {}): Promise<vo
   const paths = getHivePaths(root);
   const dbPath = join(paths.hiveDir, 'hive.db');
   debugLog(`Dashboard starting - root: ${root}, hiveDir: ${paths.hiveDir}`);
-  let db: DatabaseClient = await getDatabase(paths.hiveDir);
+  let db: ReadOnlyDatabaseClient = await getReadOnlyDatabase(paths.hiveDir);
   let lastDbMtime = statSync(dbPath).mtimeMs;
   const refreshInterval = options.refreshInterval || 5000;
   const version = getVersion();
@@ -121,7 +121,7 @@ export async function startDashboard(options: DashboardOptions = {}): Promise<vo
         lastDbMtime = currentMtime;
 
         // Get new database connection first, then close old one
-        const newDb = await getDatabase(paths.hiveDir);
+        const newDb = await getReadOnlyDatabase(paths.hiveDir);
         try {
           db.db.close();
         } catch (_error) {

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -632,15 +632,18 @@ export async function getReadOnlyDatabase(hiveDir: string): Promise<ReadOnlyData
 // Helper function to run a query and get results as objects
 export function queryAll<T>(db: SqlJsDatabase, sql: string, params: unknown[] = []): T[] {
   const stmt = db.prepare(sql);
-  stmt.bind(params);
+  try {
+    stmt.bind(params);
 
-  const results: T[] = [];
-  while (stmt.step()) {
-    const row = stmt.getAsObject();
-    results.push(row as T);
+    const results: T[] = [];
+    while (stmt.step()) {
+      const row = stmt.getAsObject();
+      results.push(row as T);
+    }
+    return results;
+  } finally {
+    stmt.free();
   }
-  stmt.free();
-  return results;
 }
 
 // Helper function to run a query and get a single result


### PR DESCRIPTION
## Summary
- use read-only DB handles in dashboard refresh/reload path to avoid write churn while viewing dashboard
- ensure sql.js statements are always freed in queryAll via try/finally

## Validation
- npm run build
- npm test -- src/db/client.test.ts src/cli/dashboard/index.test.ts
- npx eslint src/cli/dashboard/index.ts src/db/client.ts