### PR TITLE
fix(pr): make --no-merge skip auto-merge

### DIFF
--- a/src/utils/auto-merge.ts
+++ b/src/utils/auto-merge.ts
@@ -13,6 +13,7 @@ import { createLog } from '../db/queries/logs.js';
 import { getApprovedPullRequests, updatePullRequest } from '../db/queries/pull-requests.js';
 import { getStoryById, updateStory } from '../db/queries/stories.js';
 import { getAllTeams } from '../db/queries/teams.js';
+import { isManualMergeRequired } from './manual-merge.js';
 import { getHivePaths } from './paths.js';
 import { ghRepoSlug } from './pr-sync.js';
 
@@ -44,7 +45,9 @@ export async function autoMergeApprovedPRs(root: string, db: DatabaseClient): Pr
     return 0;
   }
 
-  const approvedPRs = getApprovedPullRequests(db.db);
+  const approvedPRs = getApprovedPullRequests(db.db).filter(
+    pr => !isManualMergeRequired(pr.review_notes)
+  );
   if (approvedPRs.length === 0) return 0;
 
   let mergedCount = 0;

--- a/src/utils/manual-merge.test.ts
+++ b/src/utils/manual-merge.test.ts
@@ -1,0 +1,22 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import { describe, expect, it } from 'vitest';
+import { isManualMergeRequired, markManualMergeRequired } from './manual-merge.js';
+
+describe('manual merge review note marker', () => {
+  it('marks empty notes as manual-merge-required', () => {
+    expect(markManualMergeRequired()).toBe('[manual-merge-required]');
+    expect(isManualMergeRequired(markManualMergeRequired())).toBe(true);
+  });
+
+  it('preserves existing notes while adding marker once', () => {
+    const notes = markManualMergeRequired('Needs human verification');
+    expect(notes).toContain('[manual-merge-required]');
+    expect(notes).toContain('Needs human verification');
+    expect(markManualMergeRequired(notes)).toBe(notes);
+  });
+
+  it('does not detect marker in normal notes', () => {
+    expect(isManualMergeRequired('Looks good')).toBe(false);
+  });
+});

--- a/src/utils/manual-merge.ts
+++ b/src/utils/manual-merge.ts
@@ -1,0 +1,25 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+const MANUAL_MERGE_REQUIRED_MARKER = '[manual-merge-required]';
+
+/**
+ * Mark review notes as requiring manual merge. Used by `hive pr approve --no-merge`
+ * so daemon auto-merge can skip these PRs.
+ */
+export function markManualMergeRequired(notes?: string | null): string {
+  const trimmed = notes?.trim() ?? '';
+  if (trimmed.includes(MANUAL_MERGE_REQUIRED_MARKER)) {
+    return trimmed;
+  }
+  if (trimmed.length === 0) {
+    return MANUAL_MERGE_REQUIRED_MARKER;
+  }
+  return `${MANUAL_MERGE_REQUIRED_MARKER}\n${trimmed}`;
+}
+
+/**
+ * Check whether review notes indicate that this PR must be merged manually.
+ */
+export function isManualMergeRequired(notes?: string | null): boolean {
+  return Boolean(notes && notes.includes(MANUAL_MERGE_REQUIRED_MARKER));
+}


### PR DESCRIPTION
## Summary
- fix `hive pr approve --no-merge` so it does not trigger the immediate auto-merge path
- mark manual-merge approvals in review notes and skip those PRs in daemon auto-merge
- add regression tests for approve behavior and manual-merge marker handling

## Validation
- npm test -- src/cli/commands/pr.test.ts src/utils/manual-merge.test.ts src/utils/auto-merge.test.ts
- npm run build
- npx eslint src/cli/commands/pr.ts src/cli/commands/pr.test.ts src/utils/auto-merge.ts src/utils/auto-merge.test.ts src/utils/manual-merge.ts src/utils/manual-merge.test.ts