### PR TITLE
fix(manager): proactively recover and route QA review work

### DIFF
--- a/src/cli/commands/manager/index.ts
+++ b/src/cli/commands/manager/index.ts
@@ -777,7 +777,9 @@ async function recoverUnassignedQAFailedStories(ctx: ManagerCheckContext): Promi
   );
   if (assignmentResult.errors.length > 0) {
     console.log(
-      chalk.yellow(`  Assignment errors during QA-failed recovery: ${assignmentResult.errors.length}`)
+      chalk.yellow(
+        `  Assignment errors during QA-failed recovery: ${assignmentResult.errors.length}`
+      )
     );
   }
 }


### PR DESCRIPTION
## Summary
- proactively dispatch queued PR reviews to idle QA agents instead of passive nudges
- mark dispatched PRs as `reviewing` with reviewer session and log `PR_REVIEW_STARTED`
- auto-recover `qa_failed` stories that lost assignment by moving them back to `planned` and immediately re-running assignment

## Validation
- npm test -- src/cli/commands/manager/index.test.ts
- npm run build
- npx eslint src/cli/commands/manager/index.ts