### PR TITLE
fix(manager): recover stale in-progress stories and auto-assign

### DIFF
--- a/src/db/queries/stories.ts
+++ b/src/db/queries/stories.ts
@@ -406,6 +406,18 @@ export function getStoriesWithOrphanedAssignments(
   );
 }
 
+export function getStaleInProgressStoriesWithoutAssignment(db: Database): Array<{ id: string }> {
+  return queryAll<{ id: string }>(
+    db,
+    `
+    SELECT id
+    FROM stories
+    WHERE status = 'in_progress'
+      AND assigned_agent_id IS NULL
+  `
+  );
+}
+
 /** @deprecated Use getStoryByExternalKey instead */
 export function getStoryByJiraKey(db: Database, jiraIssueKey: string): StoryRow | undefined {
   return queryOne<StoryRow>(


### PR DESCRIPTION
Summary\n- recover stale stories stuck in in_progress with no assigned agent by returning them to planned\n- include this stale state in orphan recovery pass so manager health check can fix drift automatically\n- after health/orphan recovery, manager now auto-runs assignment so work does not stay idle waiting for manual hive assign\n- add scheduler tests for stale in-progress recovery and guard that planned/unassigned stories are not touched\n\nValidation\n- npm run test -- src/orchestrator/scheduler.test.ts src/cli/commands/manager/index.test.ts\n- npm run build\n- npx eslint src/orchestrator/orphan-recovery.ts src/cli/commands/manager/index.ts src/db/queries/stories.ts src/orchestrator/scheduler.test.ts