### PR TITLE
fix: auto-clear stale manager escalations

### DIFF
--- a/src/cli/commands/manager/stale-escalations.test.ts
+++ b/src/cli/commands/manager/stale-escalations.test.ts
@@ -1,0 +1,94 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import { describe, expect, it } from 'vitest';
+import type { AgentRow, EscalationRow } from '../../../db/client.js';
+import { findStaleSessionEscalations } from './stale-escalations.js';
+
+function buildEscalation(
+  overrides: Partial<EscalationRow> = {},
+  createdAt = '2026-02-14T00:00:00.000Z'
+): EscalationRow {
+  return {
+    id: 'ESC-TEST1',
+    story_id: null,
+    from_agent_id: 'hive-intermediate-grigora',
+    to_agent_id: null,
+    reason: 'Approval required',
+    status: 'pending',
+    resolution: null,
+    created_at: createdAt,
+    resolved_at: null,
+    ...overrides,
+  };
+}
+
+function buildAgent(overrides: Partial<AgentRow> = {}): AgentRow {
+  return {
+    id: 'intermediate-1',
+    type: 'intermediate',
+    team_id: 'team-1',
+    tmux_session: 'hive-intermediate-grigora',
+    model: 'gpt-5.1-codex-mini',
+    status: 'working',
+    current_story_id: 'STORY-003',
+    memory_state: null,
+    cli_tool: 'codex',
+    worktree_path: null,
+    created_at: '2026-02-14T00:00:00.000Z',
+    updated_at: '2026-02-14T00:00:00.000Z',
+    last_seen: '2026-02-14T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('findStaleSessionEscalations', () => {
+  it('flags escalation when source agent is terminated and session is gone', () => {
+    const stale = findStaleSessionEscalations({
+      pendingEscalations: [buildEscalation()],
+      agents: [buildAgent({ status: 'terminated' })],
+      liveSessionNames: new Set<string>(),
+      nowMs: Date.parse('2026-02-14T00:10:00.000Z'),
+      staleAfterMs: 60_000,
+    });
+
+    expect(stale).toHaveLength(1);
+    expect(stale[0].reason).toContain('terminated');
+  });
+
+  it('does not flag escalation when source session is currently live', () => {
+    const stale = findStaleSessionEscalations({
+      pendingEscalations: [buildEscalation()],
+      agents: [buildAgent()],
+      liveSessionNames: new Set<string>(['hive-intermediate-grigora']),
+      nowMs: Date.parse('2026-02-14T00:10:00.000Z'),
+      staleAfterMs: 60_000,
+    });
+
+    expect(stale).toHaveLength(0);
+  });
+
+  it('flags escalation when source session/agent no longer exists', () => {
+    const stale = findStaleSessionEscalations({
+      pendingEscalations: [buildEscalation({ from_agent_id: 'hive-missing-agent' })],
+      agents: [buildAgent()],
+      liveSessionNames: new Set<string>(),
+      nowMs: Date.parse('2026-02-14T00:10:00.000Z'),
+      staleAfterMs: 60_000,
+    });
+
+    expect(stale).toHaveLength(1);
+    expect(stale[0].reason).toContain('no longer exists');
+  });
+
+  it('does not flag escalation that is younger than stale threshold', () => {
+    const stale = findStaleSessionEscalations({
+      pendingEscalations: [buildEscalation({}, '2026-02-14T00:09:40.000Z')],
+      agents: [buildAgent({ status: 'terminated' })],
+      liveSessionNames: new Set<string>(),
+      nowMs: Date.parse('2026-02-14T00:10:00.000Z'),
+      staleAfterMs: 60_000,
+    });
+
+    expect(stale).toHaveLength(0);
+  });
+});

--- a/src/cli/commands/manager/stale-escalations.ts
+++ b/src/cli/commands/manager/stale-escalations.ts
@@ -1,0 +1,104 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import type { EscalationRow } from '../../../db/client.js';
+import type { getAllAgents } from '../../../db/queries/agents.js';
+
+type AgentRecord = ReturnType<typeof getAllAgents>[number];
+
+export interface FindStaleSessionEscalationsInput {
+  pendingEscalations: EscalationRow[];
+  agents: AgentRecord[];
+  liveSessionNames: Set<string>;
+  nowMs: number;
+  staleAfterMs: number;
+}
+
+export interface StaleSessionEscalation {
+  escalation: EscalationRow;
+  reason: string;
+}
+
+function buildAgentIndexes(agents: AgentRecord[]): {
+  byId: Map<string, AgentRecord>;
+  bySession: Map<string, AgentRecord>;
+  byCanonicalSession: Map<string, AgentRecord>;
+} {
+  const byId = new Map<string, AgentRecord>();
+  const bySession = new Map<string, AgentRecord>();
+  const byCanonicalSession = new Map<string, AgentRecord>();
+
+  for (const agent of agents) {
+    byId.set(agent.id, agent);
+    byCanonicalSession.set(`hive-${agent.id}`, agent);
+    if (agent.tmux_session) {
+      bySession.set(agent.tmux_session, agent);
+    }
+  }
+
+  return { byId, bySession, byCanonicalSession };
+}
+
+function getEscalationAgeMs(escalation: EscalationRow, nowMs: number): number {
+  const createdAtMs = Date.parse(escalation.created_at);
+  if (Number.isNaN(createdAtMs)) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  return Math.max(0, nowMs - createdAtMs);
+}
+
+function hasAnyLiveAgentSession(agent: AgentRecord, liveSessionNames: Set<string>): boolean {
+  if (agent.tmux_session && liveSessionNames.has(agent.tmux_session)) {
+    return true;
+  }
+
+  if (liveSessionNames.has(`hive-${agent.id}`)) {
+    return true;
+  }
+
+  return liveSessionNames.has(agent.id);
+}
+
+export function findStaleSessionEscalations(
+  input: FindStaleSessionEscalationsInput
+): StaleSessionEscalation[] {
+  const staleEscalations: StaleSessionEscalation[] = [];
+  const { byId, bySession, byCanonicalSession } = buildAgentIndexes(input.agents);
+
+  for (const escalation of input.pendingEscalations) {
+    const source = escalation.from_agent_id;
+    if (!source) continue;
+
+    const ageMs = getEscalationAgeMs(escalation, input.nowMs);
+    if (ageMs < input.staleAfterMs) continue;
+
+    if (input.liveSessionNames.has(source)) {
+      continue;
+    }
+
+    const sourceAgent = byId.get(source) || bySession.get(source) || byCanonicalSession.get(source);
+    if (!sourceAgent) {
+      staleEscalations.push({
+        escalation,
+        reason: `source session/agent "${source}" no longer exists`,
+      });
+      continue;
+    }
+
+    if (sourceAgent.status === 'terminated') {
+      staleEscalations.push({
+        escalation,
+        reason: `source agent "${sourceAgent.id}" is terminated`,
+      });
+      continue;
+    }
+
+    if (!hasAnyLiveAgentSession(sourceAgent, input.liveSessionNames)) {
+      staleEscalations.push({
+        escalation,
+        reason: `source agent "${sourceAgent.id}" has no live tmux session`,
+      });
+    }
+  }
+
+  return staleEscalations;
+}


### PR DESCRIPTION
## Summary
- auto-resolve pending escalations when the source agent/session is stale (missing, terminated, or has no live tmux session)
- run stale cleanup every manager cycle before scanning active sessions
- add unit tests for stale escalation detection

## Validation
- npm run test -- src/cli/commands/manager/stale-escalations.test.ts src/cli/commands/manager/escalation-handler.test.ts
- npm run build
- npm run lint -- src/cli/commands/manager/index.ts src/cli/commands/manager/stale-escalations.ts src/cli/commands/manager/stale-escalations.test.ts