### PR TITLE
feat: add automatic feature sign-off trigger when all stories merged

### DIFF
--- a/src/cli/commands/manager/feature-sign-off.test.ts
+++ b/src/cli/commands/manager/feature-sign-off.test.ts
@@ -1,0 +1,321 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockGetRequirementsByStatus,
+  mockUpdateRequirement,
+  mockGetStoriesByRequirement,
+  mockGetAllTeams,
+  mockCreateLog,
+} = vi.hoisted(() => ({
+  mockGetRequirementsByStatus: vi.fn(),
+  mockUpdateRequirement: vi.fn(),
+  mockGetStoriesByRequirement: vi.fn(),
+  mockGetAllTeams: vi.fn(),
+  mockCreateLog: vi.fn(),
+}));
+
+vi.mock('../../../db/queries/requirements.js', () => ({
+  getRequirementsByStatus: (...args: unknown[]) => mockGetRequirementsByStatus(...args),
+  updateRequirement: (...args: unknown[]) => mockUpdateRequirement(...args),
+  getRequirementById: vi.fn(),
+  getAllRequirements: vi.fn(),
+  getPendingRequirements: vi.fn(),
+  createRequirement: vi.fn(),
+  deleteRequirement: vi.fn(),
+}));
+
+vi.mock('../../../db/queries/stories.js', () => ({
+  getStoriesByRequirement: (...args: unknown[]) => mockGetStoriesByRequirement(...args),
+}));
+
+vi.mock('../../../db/queries/teams.js', () => ({
+  getAllTeams: (...args: unknown[]) => mockGetAllTeams(...args),
+  getTeamById: vi.fn(),
+  getTeamByName: vi.fn(),
+  createTeam: vi.fn(),
+  deleteTeam: vi.fn(),
+}));
+
+vi.mock('../../../db/queries/logs.js', () => ({
+  createLog: (...args: unknown[]) => mockCreateLog(...args),
+  getLogsByAgent: vi.fn(),
+  getLogsByStory: vi.fn(),
+  getLogsByEventType: vi.fn(),
+  getRecentLogs: vi.fn(),
+  getLogById: vi.fn(),
+}));
+
+import type { HiveConfig } from '../../../config/schema.js';
+import type { RequirementRow, StoryRow, TeamRow } from '../../../db/client.js';
+import { checkFeatureSignOff } from './feature-sign-off.js';
+import type { ManagerCheckContext } from './types.js';
+
+function makeCtx(overrides: Partial<ManagerCheckContext> = {}): ManagerCheckContext {
+  return {
+    root: '/test',
+    verbose: false,
+    config: {
+      e2e_tests: { path: './e2e' },
+    } as unknown as HiveConfig,
+    paths: {} as ManagerCheckContext['paths'],
+    db: { db: {} as never, save: vi.fn() } as unknown as ManagerCheckContext['db'],
+    scheduler: {
+      spawnFeatureTest: vi.fn().mockResolvedValue({ id: 'team-1-feature-test-1' }),
+    } as unknown as ManagerCheckContext['scheduler'],
+    hiveSessions: [],
+    counters: {
+      nudged: 0,
+      autoProgressed: 0,
+      messagesForwarded: 0,
+      escalationsCreated: 0,
+      escalationsResolved: 0,
+      queuedPRCount: 0,
+      handoffPromoted: 0,
+      handoffAutoAssigned: 0,
+      jiraSynced: 0,
+      featureTestsSpawned: 0,
+    },
+    escalatedSessions: new Set(),
+    agentsBySessionName: new Map(),
+    messagesToMarkRead: [],
+    ...overrides,
+  };
+}
+
+function makeRequirement(overrides: Partial<RequirementRow> = {}): RequirementRow {
+  return {
+    id: 'REQ-TEST1234',
+    title: 'Test requirement',
+    description: 'Test desc',
+    submitted_by: 'human',
+    status: 'in_progress',
+    godmode: 0,
+    target_branch: 'feature/REQ-TEST1234',
+    feature_branch: 'feature/REQ-TEST1234',
+    jira_epic_key: null,
+    jira_epic_id: null,
+    external_epic_key: null,
+    external_epic_id: null,
+    external_provider: null,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeStory(overrides: Partial<StoryRow> = {}): StoryRow {
+  return {
+    id: 'STORY-TEST1',
+    requirement_id: 'REQ-TEST1234',
+    team_id: 'team-abc',
+    title: 'Test story',
+    description: 'Test story desc',
+    acceptance_criteria: null,
+    complexity: 3,
+    status: 'merged',
+    assigned_agent_id: null,
+    branch_name: null,
+    jira_issue_key: null,
+    external_issue_key: null,
+    external_provider: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  } as StoryRow;
+}
+
+function makeTeam(overrides: Partial<TeamRow> = {}): TeamRow {
+  return {
+    id: 'team-abc',
+    repo_url: 'https://github.com/test/repo',
+    repo_path: 'repos/team-abc',
+    name: 'team-abc',
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('checkFeatureSignOff', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should skip when e2e_tests is not configured', async () => {
+    const ctx = makeCtx({
+      config: {} as unknown as HiveConfig,
+    });
+
+    await checkFeatureSignOff(ctx);
+
+    expect(mockGetRequirementsByStatus).not.toHaveBeenCalled();
+    expect(ctx.counters.featureTestsSpawned).toBe(0);
+  });
+
+  it('should skip when no in_progress requirements with feature branches exist', async () => {
+    const ctx = makeCtx();
+    mockGetRequirementsByStatus.mockReturnValue([]);
+
+    await checkFeatureSignOff(ctx);
+
+    expect(ctx.counters.featureTestsSpawned).toBe(0);
+  });
+
+  it('should skip requirements without feature_branch set', async () => {
+    const ctx = makeCtx();
+    mockGetRequirementsByStatus.mockReturnValue([makeRequirement({ feature_branch: null })]);
+
+    await checkFeatureSignOff(ctx);
+
+    expect(mockGetStoriesByRequirement).not.toHaveBeenCalled();
+    expect(ctx.counters.featureTestsSpawned).toBe(0);
+  });
+
+  it('should skip when not all stories are merged', async () => {
+    const ctx = makeCtx();
+    mockGetRequirementsByStatus.mockReturnValue([makeRequirement()]);
+    mockGetStoriesByRequirement.mockReturnValue([
+      makeStory({ id: 'STORY-1', status: 'merged' }),
+      makeStory({ id: 'STORY-2', status: 'in_progress' }),
+    ]);
+    mockGetAllTeams.mockReturnValue([makeTeam()]);
+
+    await checkFeatureSignOff(ctx);
+
+    expect(ctx.counters.featureTestsSpawned).toBe(0);
+  });
+
+  it('should skip requirements with no stories', async () => {
+    const ctx = makeCtx();
+    mockGetRequirementsByStatus.mockReturnValue([makeRequirement()]);
+    mockGetStoriesByRequirement.mockReturnValue([]);
+    mockGetAllTeams.mockReturnValue([makeTeam()]);
+
+    await checkFeatureSignOff(ctx);
+
+    expect(ctx.counters.featureTestsSpawned).toBe(0);
+  });
+
+  it('should spawn feature_test agent when all stories are merged', async () => {
+    const ctx = makeCtx();
+    const req = makeRequirement();
+    mockGetRequirementsByStatus.mockReturnValue([req]);
+    mockGetStoriesByRequirement.mockReturnValue([
+      makeStory({ id: 'STORY-1', status: 'merged' }),
+      makeStory({ id: 'STORY-2', status: 'merged' }),
+    ]);
+    mockGetAllTeams.mockReturnValue([makeTeam()]);
+
+    await checkFeatureSignOff(ctx);
+
+    expect(mockUpdateRequirement).toHaveBeenCalledWith(expect.anything(), 'REQ-TEST1234', {
+      status: 'sign_off',
+    });
+    expect(ctx.scheduler.spawnFeatureTest).toHaveBeenCalledWith(
+      'team-abc',
+      'team-abc',
+      'repos/team-abc',
+      {
+        featureBranch: 'feature/REQ-TEST1234',
+        requirementId: 'REQ-TEST1234',
+        e2eTestsPath: './e2e',
+      }
+    );
+    expect(ctx.counters.featureTestsSpawned).toBe(1);
+    expect(ctx.db.save).toHaveBeenCalled();
+  });
+
+  it('should create log entries on successful spawn', async () => {
+    const ctx = makeCtx();
+    mockGetRequirementsByStatus.mockReturnValue([makeRequirement()]);
+    mockGetStoriesByRequirement.mockReturnValue([makeStory({ status: 'merged' })]);
+    mockGetAllTeams.mockReturnValue([makeTeam()]);
+
+    await checkFeatureSignOff(ctx);
+
+    expect(mockCreateLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        agentId: 'team-1-feature-test-1',
+        eventType: 'FEATURE_TEST_SPAWNED',
+      })
+    );
+    expect(mockCreateLog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        agentId: 'manager',
+        eventType: 'FEATURE_SIGN_OFF_TRIGGERED',
+      })
+    );
+  });
+
+  it('should handle multiple requirements independently', async () => {
+    const ctx = makeCtx();
+    const req1 = makeRequirement({ id: 'REQ-AAA', feature_branch: 'feature/REQ-AAA' });
+    const req2 = makeRequirement({ id: 'REQ-BBB', feature_branch: 'feature/REQ-BBB' });
+    mockGetRequirementsByStatus.mockReturnValue([req1, req2]);
+    mockGetStoriesByRequirement
+      .mockReturnValueOnce([makeStory({ id: 'S-1', status: 'merged', requirement_id: 'REQ-AAA' })])
+      .mockReturnValueOnce([
+        makeStory({ id: 'S-2', status: 'merged', requirement_id: 'REQ-BBB' }),
+        makeStory({ id: 'S-3', status: 'in_progress', requirement_id: 'REQ-BBB' }),
+      ]);
+    mockGetAllTeams.mockReturnValue([makeTeam()]);
+
+    await checkFeatureSignOff(ctx);
+
+    // Only req1 should spawn (all merged); req2 has a non-merged story
+    expect(ctx.counters.featureTestsSpawned).toBe(1);
+    expect(mockUpdateRequirement).toHaveBeenCalledTimes(1);
+    expect(mockUpdateRequirement).toHaveBeenCalledWith(expect.anything(), 'REQ-AAA', {
+      status: 'sign_off',
+    });
+  });
+
+  it('should skip when story has no team_id', async () => {
+    const ctx = makeCtx();
+    mockGetRequirementsByStatus.mockReturnValue([makeRequirement()]);
+    mockGetStoriesByRequirement.mockReturnValue([
+      makeStory({ status: 'merged', team_id: null as unknown as string }),
+    ]);
+    mockGetAllTeams.mockReturnValue([makeTeam()]);
+
+    await checkFeatureSignOff(ctx);
+
+    expect(ctx.counters.featureTestsSpawned).toBe(0);
+  });
+
+  it('should skip when team is not found', async () => {
+    const ctx = makeCtx();
+    mockGetRequirementsByStatus.mockReturnValue([makeRequirement()]);
+    mockGetStoriesByRequirement.mockReturnValue([
+      makeStory({ status: 'merged', team_id: 'team-unknown' }),
+    ]);
+    mockGetAllTeams.mockReturnValue([makeTeam({ id: 'team-other' })]);
+
+    await checkFeatureSignOff(ctx);
+
+    expect(ctx.counters.featureTestsSpawned).toBe(0);
+  });
+
+  it('should revert requirement status on spawn failure', async () => {
+    const ctx = makeCtx({
+      scheduler: {
+        spawnFeatureTest: vi.fn().mockRejectedValue(new Error('spawn failed')),
+      } as unknown as ManagerCheckContext['scheduler'],
+    });
+    mockGetRequirementsByStatus.mockReturnValue([makeRequirement()]);
+    mockGetStoriesByRequirement.mockReturnValue([makeStory({ status: 'merged' })]);
+    mockGetAllTeams.mockReturnValue([makeTeam()]);
+
+    await checkFeatureSignOff(ctx);
+
+    expect(mockUpdateRequirement).toHaveBeenCalledWith(expect.anything(), 'REQ-TEST1234', {
+      status: 'sign_off',
+    });
+    expect(mockUpdateRequirement).toHaveBeenCalledWith(expect.anything(), 'REQ-TEST1234', {
+      status: 'in_progress',
+    });
+    expect(ctx.counters.featureTestsSpawned).toBe(0);
+  });
+});

--- a/src/cli/commands/manager/feature-sign-off.ts
+++ b/src/cli/commands/manager/feature-sign-off.ts
@@ -1,0 +1,116 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import chalk from 'chalk';
+import { createLog } from '../../../db/queries/logs.js';
+import { getRequirementsByStatus, updateRequirement } from '../../../db/queries/requirements.js';
+import { getStoriesByRequirement } from '../../../db/queries/stories.js';
+import { getAllTeams } from '../../../db/queries/teams.js';
+import type { ManagerCheckContext } from './types.js';
+
+function verboseLogCtx(ctx: Pick<ManagerCheckContext, 'verbose'>, message: string): void {
+  if (!ctx.verbose) return;
+  console.log(chalk.gray(`  [verbose] ${message}`));
+}
+
+export async function checkFeatureSignOff(ctx: ManagerCheckContext): Promise<void> {
+  if (!ctx.config.e2e_tests?.path) {
+    verboseLogCtx(ctx, 'checkFeatureSignOff: skip=no_e2e_tests_configured');
+    return;
+  }
+
+  const inProgressReqs = getRequirementsByStatus(ctx.db.db, 'in_progress').filter(
+    req => req.feature_branch
+  );
+  verboseLogCtx(ctx, `checkFeatureSignOff: candidates=${inProgressReqs.length}`);
+
+  if (inProgressReqs.length === 0) return;
+
+  const teams = getAllTeams(ctx.db.db);
+  const e2eTestsPath = ctx.config.e2e_tests.path;
+
+  for (const req of inProgressReqs) {
+    const stories = getStoriesByRequirement(ctx.db.db, req.id);
+    if (stories.length === 0) {
+      verboseLogCtx(ctx, `checkFeatureSignOff: req=${req.id} skip=no_stories`);
+      continue;
+    }
+
+    const allMerged = stories.every(story => story.status === 'merged');
+    if (!allMerged) {
+      const mergedCount = stories.filter(s => s.status === 'merged').length;
+      verboseLogCtx(
+        ctx,
+        `checkFeatureSignOff: req=${req.id} skip=not_all_merged (${mergedCount}/${stories.length})`
+      );
+      continue;
+    }
+
+    // All stories merged - find the team from the first story
+    const teamId = stories[0].team_id;
+    if (!teamId) {
+      verboseLogCtx(ctx, `checkFeatureSignOff: req=${req.id} skip=no_team_id`);
+      continue;
+    }
+
+    const team = teams.find(t => t.id === teamId);
+    if (!team) {
+      verboseLogCtx(ctx, `checkFeatureSignOff: req=${req.id} skip=team_not_found id=${teamId}`);
+      continue;
+    }
+
+    verboseLogCtx(
+      ctx,
+      `checkFeatureSignOff: req=${req.id} all_merged=${stories.length} stories, spawning feature_test`
+    );
+
+    try {
+      // Transition requirement to sign_off
+      updateRequirement(ctx.db.db, req.id, { status: 'sign_off' });
+
+      // Spawn feature_test agent
+      const agent = await ctx.scheduler.spawnFeatureTest(teamId, team.name, team.repo_path, {
+        featureBranch: req.feature_branch!,
+        requirementId: req.id,
+        e2eTestsPath,
+      });
+
+      createLog(ctx.db.db, {
+        agentId: agent.id,
+        eventType: 'FEATURE_TEST_SPAWNED',
+        message: `Spawned feature_test agent for requirement ${req.id} (branch: ${req.feature_branch})`,
+        metadata: {
+          requirement_id: req.id,
+          feature_branch: req.feature_branch,
+          team_id: teamId,
+          stories_merged: stories.length,
+        },
+      });
+      createLog(ctx.db.db, {
+        agentId: 'manager',
+        eventType: 'FEATURE_SIGN_OFF_TRIGGERED',
+        message: `All ${stories.length} stories merged for ${req.id} — triggered feature sign-off`,
+        metadata: {
+          requirement_id: req.id,
+          feature_branch: req.feature_branch,
+          agent_id: agent.id,
+        },
+      });
+
+      ctx.db.save();
+      ctx.counters.featureTestsSpawned++;
+      console.log(
+        chalk.green(
+          `  Feature sign-off: spawned E2E test agent for ${req.id} (${stories.length} stories merged)`
+        )
+      );
+    } catch (err) {
+      // Revert status on failure
+      updateRequirement(ctx.db.db, req.id, { status: 'in_progress' });
+      ctx.db.save();
+      console.error(
+        chalk.red(`  Feature sign-off failed for ${req.id}:`),
+        err instanceof Error ? err.message : err
+      );
+    }
+  }
+}

--- a/src/cli/commands/manager/index.ts
+++ b/src/cli/commands/manager/index.ts
@@ -71,6 +71,7 @@ import {
 } from './agent-monitoring.js';
 import { assessCompletionFromOutput } from './done-intelligence.js';
 import { handleEscalationAndNudge } from './escalation-handler.js';
+import { checkFeatureSignOff } from './feature-sign-off.js';
 import { handleStalledPlanningHandoff } from './handoff-recovery.js';
 import { shouldAutoResolveOrphanedManagerEscalation } from './orphaned-escalations.js';
 import { findSessionForAgent } from './session-resolution.js';
@@ -755,6 +756,7 @@ async function managerCheck(
         handoffPromoted: 0,
         handoffAutoAssigned: 0,
         jiraSynced: 0,
+        featureTestsSpawned: 0,
       },
       escalatedSessions: new Set(),
       agentsBySessionName: new Map(),
@@ -811,6 +813,8 @@ async function managerCheck(
     await nudgeQAFailedStories(ctx);
     verboseLogCtx(ctx, 'Step: spin down merged agents');
     await spinDownMergedAgents(ctx);
+    verboseLogCtx(ctx, 'Step: check feature sign-off readiness');
+    await checkFeatureSignOff(ctx);
     verboseLogCtx(ctx, 'Step: spin down idle agents');
     await spinDownIdleAgents(ctx);
     verboseLogCtx(ctx, 'Step: evaluate stuck stories');
@@ -1989,6 +1993,7 @@ function printSummary(ctx: ManagerCheckContext): void {
     handoffPromoted,
     handoffAutoAssigned,
     jiraSynced,
+    featureTestsSpawned,
   } = ctx.counters;
   const summary = [];
 
@@ -2001,6 +2006,7 @@ function printSummary(ctx: ManagerCheckContext): void {
   if (handoffPromoted > 0) summary.push(`${handoffPromoted} auto-promoted from estimated`);
   if (handoffAutoAssigned > 0) summary.push(`${handoffAutoAssigned} auto-assigned after recovery`);
   if (jiraSynced > 0) summary.push(`${jiraSynced} synced from Jira`);
+  if (featureTestsSpawned > 0) summary.push(`${featureTestsSpawned} feature test(s) spawned`);
 
   if (summary.length > 0) {
     console.log(chalk.yellow(`  ${summary.join(', ')}`));

--- a/src/cli/commands/manager/types.ts
+++ b/src/cli/commands/manager/types.ts
@@ -69,6 +69,7 @@ export interface ManagerCheckContext {
     handoffPromoted: number;
     handoffAutoAssigned: number;
     jiraSynced: number;
+    featureTestsSpawned: number;
   };
   // Shared state for dedup
   escalatedSessions: Set<string | null>;

--- a/src/db/queries/logs.ts
+++ b/src/db/queries/logs.ts
@@ -65,7 +65,9 @@ export type EventType =
   | 'JIRA_ASSIGNMENT_REPAIR_FAILED'
   | 'APPROACH_POSTED'
   | 'FEATURE_BRANCH_CREATED'
-  | 'FEATURE_BRANCH_FAILED';
+  | 'FEATURE_BRANCH_FAILED'
+  | 'FEATURE_TEST_SPAWNED'
+  | 'FEATURE_SIGN_OFF_TRIGGERED';
 
 export interface CreateLogInput {
   agentId: string;


### PR DESCRIPTION
## Summary
- Adds `checkFeatureSignOff` to the manager daemon that detects when all stories for a requirement have status `merged`
- Transitions the requirement to `sign_off` status and spawns a `feature_test` agent to run E2E tests via `scheduler.spawnFeatureTest()`
- Reverts requirement status to `in_progress` on spawn failure; skips gracefully when `e2e_tests` is not configured

## Test plan
- [x] 11 unit tests covering all paths: no e2e config, no requirements, not all merged, successful spawn, log entries, multiple requirements, missing team, spawn failure rollback
- [x] Full test suite passes (1682 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)