### PR TITLE
refactor: replace copy-pasted migration blocks with loop-driven runner

### DIFF
--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,13 +1,10 @@
 // Licensed under the Hungry Ghost Hive License. See LICENSE.
 
 import { copyFileSync, existsSync, readFileSync, renameSync, statSync, writeFileSync } from 'fs';
-import { dirname, join } from 'path';
+import { join } from 'path';
 import initSqlJs, { Database as SqlJsDatabase } from 'sql.js';
-import { fileURLToPath } from 'url';
 import { DatabaseCorruptionError, InitializationError } from '../errors/index.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import { MIGRATIONS } from './migrations/index.js';
 
 export interface DatabaseClient {
   db: SqlJsDatabase;
@@ -19,16 +16,6 @@ export interface DatabaseClient {
 export interface ReadOnlyDatabaseClient {
   db: SqlJsDatabase;
   close: () => void;
-}
-
-/**
- * Load migration SQL from file
- * @param migrationName Name of the migration file (e.g., '001-initial.sql')
- * @returns SQL content of the migration file
- */
-function loadMigration(migrationName: string): string {
-  const migrationPath = join(__dirname, 'migrations', migrationName);
-  return readFileSync(migrationPath, 'utf-8');
 }
 
 let SQL: Awaited<ReturnType<typeof initSqlJs>> | null = null;
@@ -197,459 +184,34 @@ function runMigrations(db: SqlJsDatabase): void {
     )
   `);
 
-  // Check if initial migration was applied
-  const result = db.exec("SELECT name FROM migrations WHERE name = '001-initial.sql'");
-  const initialMigration = result.length > 0 && result[0].values.length > 0;
-
-  if (!initialMigration) {
-    // Apply initial migration
-    const initialSql = loadMigration('001-initial.sql');
-    db.run(initialSql);
-    db.run("INSERT INTO migrations (name) VALUES ('001-initial.sql')");
-  }
-
-  // Migration 002: Add model column to agents table
-  const result002 = db.exec("SELECT name FROM migrations WHERE name = '002-add-agent-model.sql'");
-  const migration002Applied = result002.length > 0 && result002[0].values.length > 0;
-
-  if (!migration002Applied) {
-    // Check if column already exists (might be new DB with updated initial migration)
-    const columns = db.exec('PRAGMA table_info(agents)');
-    const hasModelColumn =
-      columns.length > 0 && columns[0].values.some((col: unknown[]) => col[1] === 'model');
-
-    if (!hasModelColumn) {
-      const migration002Sql = loadMigration('002-add-agent-model.sql');
-      db.run(migration002Sql);
-    }
-    db.run("INSERT INTO migrations (name) VALUES ('002-add-agent-model.sql')");
-  }
-
-  // Migration 003: Fix pull_requests table schema for merge queue
-  const result003 = db.exec("SELECT name FROM migrations WHERE name = '003-fix-pull-requests.sql'");
-  const migration003Applied = result003.length > 0 && result003[0].values.length > 0;
-
-  if (!migration003Applied) {
-    // Check if table needs migration (missing branch_name column)
-    const prColumns = db.exec('PRAGMA table_info(pull_requests)');
-    const hasBranchName =
-      prColumns.length > 0 &&
-      prColumns[0].values.some((col: unknown[]) => col[1] === 'branch_name');
-
-    if (!hasBranchName) {
-      const migration003Sql = loadMigration('003-fix-pull-requests.sql');
-      // Use db.exec() to handle multiple statements with comments properly
-      db.exec(migration003Sql);
-    }
-
-    db.run("INSERT INTO migrations (name) VALUES ('003-fix-pull-requests.sql')");
-  }
-
-  // Migration 004: Add messages table for inter-agent communication
-  const result004 = db.exec("SELECT name FROM migrations WHERE name = '004-add-messages.sql'");
-  const migration004Applied = result004.length > 0 && result004[0].values.length > 0;
-
-  if (!migration004Applied) {
-    // Check if table already exists
-    const tables = db.exec("SELECT name FROM sqlite_master WHERE type='table' AND name='messages'");
-    const hasMessagesTable = tables.length > 0 && tables[0].values.length > 0;
-
-    if (!hasMessagesTable) {
-      const migration004Sql = loadMigration('004-add-messages.sql');
-      db.run(migration004Sql);
-    }
-
-    db.run("INSERT INTO migrations (name) VALUES ('004-add-messages.sql')");
-  }
-
-  // Migration 005: Add last_seen column to agents for heartbeat mechanism
-  const result005 = db.exec(
-    "SELECT name FROM migrations WHERE name = '005-add-agent-last-seen.sql'"
+  // Query all applied migrations once
+  const appliedResult = db.exec('SELECT name FROM migrations');
+  const appliedMigrations = new Set(
+    appliedResult.length > 0 ? appliedResult[0].values.map(row => String(row[0])) : []
   );
-  const migration005Applied = result005.length > 0 && result005[0].values.length > 0;
 
-  if (!migration005Applied) {
-    const columns = db.exec('PRAGMA table_info(agents)');
-    const hasLastSeenColumn =
-      columns.length > 0 && columns[0].values.some((col: unknown[]) => col[1] === 'last_seen');
+  // Apply each migration in dependency order
+  for (const migration of MIGRATIONS) {
+    if (appliedMigrations.has(migration.name)) continue;
 
-    if (!hasLastSeenColumn) {
-      // sql.js doesn't support non-constant defaults in ALTER TABLE
-      db.run('ALTER TABLE agents ADD COLUMN last_seen TIMESTAMP');
-    }
-    db.run("INSERT INTO migrations (name) VALUES ('005-add-agent-last-seen.sql')");
+    migration.up(db);
+    db.run('INSERT INTO migrations (name) VALUES (?)', [migration.name]);
   }
+}
 
-  // Migration 006: Add worktree_path column to agents for git worktree isolation
-  const result006 = db.exec(
-    "SELECT name FROM migrations WHERE name = '006-add-agent-worktree.sql'"
+/**
+ * Returns the status of all known migrations: which are applied and which are pending.
+ */
+export function getMigrationStatus(db: SqlJsDatabase): Array<{ name: string; applied: boolean }> {
+  const appliedResult = db.exec('SELECT name FROM migrations');
+  const appliedMigrations = new Set(
+    appliedResult.length > 0 ? appliedResult[0].values.map(row => String(row[0])) : []
   );
-  const migration006Applied = result006.length > 0 && result006[0].values.length > 0;
 
-  if (!migration006Applied) {
-    const columns = db.exec('PRAGMA table_info(agents)');
-    const hasWorktreePathColumn =
-      columns.length > 0 && columns[0].values.some((col: unknown[]) => col[1] === 'worktree_path');
-
-    if (!hasWorktreePathColumn) {
-      db.run('ALTER TABLE agents ADD COLUMN worktree_path TEXT');
-    }
-    db.run("INSERT INTO migrations (name) VALUES ('006-add-agent-worktree.sql')");
-  }
-
-  // Migration 007: Add database indexes for query performance
-  const result007 = db.exec("SELECT name FROM migrations WHERE name = '007-add-indexes.sql'");
-  const migration007Applied = result007.length > 0 && result007[0].values.length > 0;
-
-  if (!migration007Applied) {
-    // Create indexes on frequently-queried columns
-    db.run('CREATE INDEX IF NOT EXISTS idx_stories_status ON stories(status)');
-    db.run('CREATE INDEX IF NOT EXISTS idx_stories_team_id ON stories(team_id)');
-    db.run(
-      'CREATE INDEX IF NOT EXISTS idx_stories_assigned_agent_id ON stories(assigned_agent_id)'
-    );
-    db.run('CREATE INDEX IF NOT EXISTS idx_stories_requirement_id ON stories(requirement_id)');
-    db.run('CREATE INDEX IF NOT EXISTS idx_agents_team_id ON agents(team_id)');
-    db.run('CREATE INDEX IF NOT EXISTS idx_agents_status ON agents(status)');
-    db.run(
-      'CREATE INDEX IF NOT EXISTS idx_pull_requests_team_status ON pull_requests(team_id, status)'
-    );
-    db.run('CREATE INDEX IF NOT EXISTS idx_pull_requests_story_id ON pull_requests(story_id)');
-    db.run('CREATE INDEX IF NOT EXISTS idx_messages_to_session ON messages(to_session)');
-    db.run('CREATE INDEX IF NOT EXISTS idx_escalations_status ON escalations(status)');
-
-    db.run("INSERT INTO migrations (name) VALUES ('007-add-indexes.sql')");
-  }
-
-  // Migration 008: Add godmode column to requirements table
-  const result008 = db.exec("SELECT name FROM migrations WHERE name = '008-add-godmode.sql'");
-  const migration008Applied = result008.length > 0 && result008[0].values.length > 0;
-
-  if (!migration008Applied) {
-    const columns = db.exec('PRAGMA table_info(requirements)');
-    const hasGodmodeColumn =
-      columns.length > 0 && columns[0].values.some((col: unknown[]) => col[1] === 'godmode');
-
-    if (!hasGodmodeColumn) {
-      const migration008Sql = loadMigration('008-add-godmode.sql');
-      db.run(migration008Sql);
-    }
-    db.run("INSERT INTO migrations (name) VALUES ('008-add-godmode.sql')");
-  }
-
-  // Migration 009: Add pull request sync indexes for faster identifier lookups
-  const result009 = db.exec(
-    "SELECT name FROM migrations WHERE name = '009-add-pr-sync-indexes.sql'"
-  );
-  const migration009Applied = result009.length > 0 && result009[0].values.length > 0;
-
-  if (!migration009Applied) {
-    const migration009Sql = loadMigration('009-add-pr-sync-indexes.sql');
-    // Use db.exec() to handle multiple statements with comments properly
-    db.exec(migration009Sql);
-    db.run("INSERT INTO migrations (name) VALUES ('009-add-pr-sync-indexes.sql')");
-  }
-
-  // Migration 010: Add target_branch column to requirements table
-  const result010 = db.exec("SELECT name FROM migrations WHERE name = '010-add-target-branch.sql'");
-  const migration010Applied = result010.length > 0 && result010[0].values.length > 0;
-
-  if (!migration010Applied) {
-    const columns = db.exec('PRAGMA table_info(requirements)');
-    const hasTargetBranchColumn =
-      columns.length > 0 && columns[0].values.some((col: unknown[]) => col[1] === 'target_branch');
-
-    if (!hasTargetBranchColumn) {
-      const migration010Sql = loadMigration('010-add-target-branch.sql');
-      db.run(migration010Sql);
-    }
-    db.run("INSERT INTO migrations (name) VALUES ('010-add-target-branch.sql')");
-  }
-
-  // Migration 006: Add comprehensive Jira integration fields and sync table
-  const result006Jira = db.exec("SELECT name FROM migrations WHERE name = '006-integrations.sql'");
-  const migration006JiraApplied = result006Jira.length > 0 && result006Jira[0].values.length > 0;
-
-  if (!migration006JiraApplied) {
-    // Add columns to stories table
-    const storyColumns = db.exec('PRAGMA table_info(stories)');
-    const storyColumnNames =
-      storyColumns.length > 0 ? storyColumns[0].values.map((col: unknown[]) => String(col[1])) : [];
-    const storyColumnsToAdd = [
-      'jira_issue_key',
-      'jira_issue_id',
-      'jira_project_key',
-      'jira_subtask_key',
-      'jira_subtask_id',
-    ];
-    for (const col of storyColumnsToAdd) {
-      if (!storyColumnNames.includes(col)) {
-        db.run(`ALTER TABLE stories ADD COLUMN ${col} TEXT`);
-      }
-    }
-
-    // Add columns to requirements table
-    const reqColumns = db.exec('PRAGMA table_info(requirements)');
-    const reqColumnNames =
-      reqColumns.length > 0 ? reqColumns[0].values.map((col: unknown[]) => String(col[1])) : [];
-    const reqColumnsToAdd = ['jira_epic_key', 'jira_epic_id'];
-    for (const col of reqColumnsToAdd) {
-      if (!reqColumnNames.includes(col)) {
-        db.run(`ALTER TABLE requirements ADD COLUMN ${col} TEXT`);
-      }
-    }
-
-    // Add column to pull_requests table
-    const prColumns = db.exec('PRAGMA table_info(pull_requests)');
-    const prColumnNames =
-      prColumns.length > 0 ? prColumns[0].values.map((col: unknown[]) => String(col[1])) : [];
-    if (!prColumnNames.includes('jira_issue_key')) {
-      db.run('ALTER TABLE pull_requests ADD COLUMN jira_issue_key TEXT');
-    }
-
-    // Create integration_sync table
-    const syncTables = db.exec(
-      "SELECT name FROM sqlite_master WHERE type='table' AND name='integration_sync'"
-    );
-    if (syncTables.length === 0 || syncTables[0].values.length === 0) {
-      db.run(`
-        CREATE TABLE integration_sync (
-          id TEXT PRIMARY KEY,
-          entity_type TEXT NOT NULL CHECK (entity_type IN ('story', 'requirement', 'pull_request')),
-          entity_id TEXT NOT NULL,
-          provider TEXT NOT NULL CHECK (provider IN ('jira', 'github', 'confluence')),
-          external_id TEXT NOT NULL,
-          last_synced_at TIMESTAMP,
-          sync_status TEXT DEFAULT 'pending' CHECK (sync_status IN ('pending', 'synced', 'failed')),
-          error_message TEXT,
-          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-          updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-        )
-      `);
-
-      // Create indexes on integration_sync table
-      db.run(
-        'CREATE INDEX IF NOT EXISTS idx_integration_sync_entity ON integration_sync(entity_type, entity_id)'
-      );
-      db.run(
-        'CREATE INDEX IF NOT EXISTS idx_integration_sync_provider ON integration_sync(provider, external_id)'
-      );
-      db.run(
-        'CREATE INDEX IF NOT EXISTS idx_integration_sync_status ON integration_sync(sync_status)'
-      );
-      db.run(
-        'CREATE INDEX IF NOT EXISTS idx_integration_sync_last_synced ON integration_sync(last_synced_at)'
-      );
-    }
-
-    db.run("INSERT INTO migrations (name) VALUES ('006-integrations.sql')");
-  }
-
-  // Migration 011: Add generic provider-agnostic integration fields
-  const result011 = db.exec(
-    "SELECT name FROM migrations WHERE name = '011-generic-integration-fields.sql'"
-  );
-  const migration011Applied = result011.length > 0 && result011[0].values.length > 0;
-
-  if (!migration011Applied) {
-    // Add generic columns to stories table
-    const storyColumns011 = db.exec('PRAGMA table_info(stories)');
-    const storyColNames011 =
-      storyColumns011.length > 0
-        ? storyColumns011[0].values.map((col: unknown[]) => String(col[1]))
-        : [];
-    const storyGenericCols = [
-      'external_issue_key',
-      'external_issue_id',
-      'external_project_key',
-      'external_subtask_key',
-      'external_subtask_id',
-      'external_provider',
-    ];
-    for (const col of storyGenericCols) {
-      if (!storyColNames011.includes(col)) {
-        db.run(`ALTER TABLE stories ADD COLUMN ${col} TEXT`);
-      }
-    }
-
-    // Add generic columns to requirements table
-    const reqColumns011 = db.exec('PRAGMA table_info(requirements)');
-    const reqColNames011 =
-      reqColumns011.length > 0
-        ? reqColumns011[0].values.map((col: unknown[]) => String(col[1]))
-        : [];
-    const reqGenericCols = ['external_epic_key', 'external_epic_id', 'external_provider'];
-    for (const col of reqGenericCols) {
-      if (!reqColNames011.includes(col)) {
-        db.run(`ALTER TABLE requirements ADD COLUMN ${col} TEXT`);
-      }
-    }
-
-    // Load and execute the data migration and index creation from file
-    const migration011Sql = loadMigration('011-generic-integration-fields.sql');
-    // Execute the UPDATE and CREATE INDEX statements (ALTER TABLE already done above)
-    const statements = migration011Sql
-      .split(';')
-      .map(s => s.trim())
-      .filter(s => {
-        if (s.length === 0) return false;
-        // Skip ALTER TABLE statements (already handled above with existence checks)
-        if (s.includes('ALTER TABLE')) return false;
-        // Filter out pure comment blocks
-        const lines = s
-          .split('\n')
-          .map(l => l.trim())
-          .filter(l => l.length > 0);
-        const hasNonCommentLine = lines.some(l => !l.startsWith('--'));
-        return hasNonCommentLine;
-      });
-
-    for (const stmt of statements) {
-      db.run(stmt);
-    }
-
-    db.run("INSERT INTO migrations (name) VALUES ('011-generic-integration-fields.sql')");
-  }
-
-  // Migration 012: Add in_sprint column and unique constraint on integration_sync
-  const result012 = db.exec("SELECT name FROM migrations WHERE name = '012-sprint-tracking.sql'");
-  const migration012Applied = result012.length > 0 && result012[0].values.length > 0;
-
-  if (!migration012Applied) {
-    // Add in_sprint column to stories table
-    const storyColumns012 = db.exec('PRAGMA table_info(stories)');
-    const storyColNames012 =
-      storyColumns012.length > 0
-        ? storyColumns012[0].values.map((col: unknown[]) => String(col[1]))
-        : [];
-
-    if (!storyColNames012.includes('in_sprint')) {
-      db.run('ALTER TABLE stories ADD COLUMN in_sprint INTEGER DEFAULT 0');
-    }
-
-    // Load and execute the index creation from file
-    const migration012Sql = loadMigration('012-sprint-tracking.sql');
-    // Execute CREATE INDEX statement (ALTER TABLE already done above)
-    const statements = migration012Sql
-      .split(';')
-      .map(s => s.trim())
-      .filter(s => {
-        if (s.length === 0) return false;
-        // Skip ALTER TABLE statements (already handled above)
-        if (s.includes('ALTER TABLE')) return false;
-        // Filter out pure comment blocks
-        const lines = s
-          .split('\n')
-          .map(l => l.trim())
-          .filter(l => l.length > 0);
-        const hasNonCommentLine = lines.some(l => !l.startsWith('--'));
-        return hasNonCommentLine;
-      });
-
-    for (const stmt of statements) {
-      db.run(stmt);
-    }
-
-    db.run("INSERT INTO migrations (name) VALUES ('012-sprint-tracking.sql')");
-  }
-
-  // Migration 013: Add feature testing support
-  // - Adds feature_branch column to requirements
-  // - Recreates agents table with feature_test in type CHECK constraint
-  // - Recreates requirements table with sign-off statuses in status CHECK constraint
-  const result013 = db.exec(
-    "SELECT name FROM migrations WHERE name = '013-feature-testing-support.sql'"
-  );
-  const migration013Applied = result013.length > 0 && result013[0].values.length > 0;
-
-  if (!migration013Applied) {
-    // 1. Add feature_branch column to requirements
-    const reqColumns013 = db.exec('PRAGMA table_info(requirements)');
-    const hasFeatureBranchColumn =
-      reqColumns013.length > 0 &&
-      reqColumns013[0].values.some((col: unknown[]) => col[1] === 'feature_branch');
-
-    if (!hasFeatureBranchColumn) {
-      const migration013Sql = loadMigration('013-feature-testing-support.sql');
-      db.run(migration013Sql);
-    }
-
-    // 2. Recreate agents table with updated type CHECK constraint (add 'feature_test')
-    db.run('PRAGMA foreign_keys = OFF');
-
-    db.run(`
-      CREATE TABLE agents_new (
-        id TEXT PRIMARY KEY,
-        type TEXT NOT NULL CHECK (type IN ('tech_lead', 'senior', 'intermediate', 'junior', 'qa', 'feature_test')),
-        team_id TEXT REFERENCES teams(id),
-        tmux_session TEXT,
-        model TEXT,
-        status TEXT DEFAULT 'idle' CHECK (status IN ('idle', 'working', 'blocked', 'terminated')),
-        current_story_id TEXT,
-        memory_state TEXT,
-        last_seen TIMESTAMP,
-        worktree_path TEXT,
-        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-      )
-    `);
-    db.run('INSERT INTO agents_new SELECT * FROM agents');
-    db.run('DROP TABLE agents');
-    db.run('ALTER TABLE agents_new RENAME TO agents');
-
-    // Recreate agents indexes
-    db.run('CREATE INDEX IF NOT EXISTS idx_agents_team_id ON agents(team_id)');
-    db.run('CREATE INDEX IF NOT EXISTS idx_agents_status ON agents(status)');
-
-    // 3. Recreate requirements table with updated status CHECK constraint
-    db.run(`
-      CREATE TABLE requirements_new (
-        id TEXT PRIMARY KEY,
-        title TEXT NOT NULL,
-        description TEXT NOT NULL,
-        submitted_by TEXT DEFAULT 'human',
-        status TEXT DEFAULT 'pending' CHECK (status IN ('pending', 'planning', 'planned', 'in_progress', 'completed', 'sign_off', 'sign_off_failed', 'sign_off_passed')),
-        godmode BOOLEAN DEFAULT 0,
-        target_branch TEXT DEFAULT 'main',
-        feature_branch TEXT,
-        jira_epic_key TEXT,
-        jira_epic_id TEXT,
-        external_epic_key TEXT,
-        external_epic_id TEXT,
-        external_provider TEXT,
-        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-      )
-    `);
-    db.run(`
-      INSERT INTO requirements_new (id, title, description, submitted_by, status, godmode, target_branch, feature_branch, jira_epic_key, jira_epic_id, external_epic_key, external_epic_id, external_provider, created_at)
-      SELECT id, title, description, submitted_by, status, godmode, target_branch, feature_branch, jira_epic_key, jira_epic_id, external_epic_key, external_epic_id, external_provider, created_at
-      FROM requirements
-    `);
-    db.run('DROP TABLE requirements');
-    db.run('ALTER TABLE requirements_new RENAME TO requirements');
-
-    db.run('PRAGMA foreign_keys = ON');
-
-    db.run("INSERT INTO migrations (name) VALUES ('013-feature-testing-support.sql')");
-  }
-
-  // Migration 007: Backfill story_points from complexity_score
-  const result007Backfill = db.exec(
-    "SELECT name FROM migrations WHERE name = '007-backfill-story-points.sql'"
-  );
-  const migration007BackfillApplied =
-    result007Backfill.length > 0 && result007Backfill[0].values.length > 0;
-
-  if (!migration007BackfillApplied) {
-    // Backfill story_points from complexity_score where story_points is NULL
-    db.run(`
-      UPDATE stories
-      SET story_points = complexity_score
-      WHERE story_points IS NULL
-        AND complexity_score IS NOT NULL
-    `);
-    db.run("INSERT INTO migrations (name) VALUES ('007-backfill-story-points.sql')");
-  }
+  return MIGRATIONS.map(m => ({
+    name: m.name,
+    applied: appliedMigrations.has(m.name),
+  }));
 }
 
 export async function getDatabase(hiveDir: string): Promise<DatabaseClient> {

--- a/src/db/migrations/index.ts
+++ b/src/db/migrations/index.ts
@@ -1,0 +1,334 @@
+// Licensed under the Hungry Ghost Hive License. See LICENSE.
+
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import type { Database as SqlJsDatabase } from 'sql.js';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export interface MigrationDefinition {
+  name: string;
+  up: (db: SqlJsDatabase) => void;
+}
+
+function loadMigrationSql(migrationName: string): string {
+  const migrationPath = join(__dirname, migrationName);
+  return readFileSync(migrationPath, 'utf-8');
+}
+
+/** Check if a column exists on a table */
+function hasColumn(db: SqlJsDatabase, table: string, column: string): boolean {
+  const columns = db.exec(`PRAGMA table_info(${table})`);
+  return columns.length > 0 && columns[0].values.some((col: unknown[]) => col[1] === column);
+}
+
+/** Get all column names for a table */
+function getColumnNames(db: SqlJsDatabase, table: string): string[] {
+  const columns = db.exec(`PRAGMA table_info(${table})`);
+  return columns.length > 0 ? columns[0].values.map((col: unknown[]) => String(col[1])) : [];
+}
+
+/** Check if a table exists */
+function hasTable(db: SqlJsDatabase, tableName: string): boolean {
+  const tables = db.exec(
+    `SELECT name FROM sqlite_master WHERE type='table' AND name='${tableName}'`
+  );
+  return tables.length > 0 && tables[0].values.length > 0;
+}
+
+/**
+ * Filter SQL file into executable statements, skipping ALTER TABLE and pure comment blocks.
+ * Used for migrations that handle ALTER TABLE separately with existence checks.
+ */
+function execNonAlterStatements(db: SqlJsDatabase, sql: string): void {
+  const statements = sql
+    .split(';')
+    .map(s => s.trim())
+    .filter(s => {
+      if (s.length === 0) return false;
+      if (s.includes('ALTER TABLE')) return false;
+      const lines = s
+        .split('\n')
+        .map(l => l.trim())
+        .filter(l => l.length > 0);
+      return lines.some(l => !l.startsWith('--'));
+    });
+
+  for (const stmt of statements) {
+    db.run(stmt);
+  }
+}
+
+/** Add columns to a table if they don't already exist */
+function addColumnsIfMissing(
+  db: SqlJsDatabase,
+  table: string,
+  columns: Array<{ name: string; type: string }>
+): void {
+  const existing = getColumnNames(db, table);
+  for (const col of columns) {
+    if (!existing.includes(col.name)) {
+      db.run(`ALTER TABLE ${table} ADD COLUMN ${col.name} ${col.type}`);
+    }
+  }
+}
+
+/**
+ * All migrations in dependency order.
+ *
+ * Note: The numbering is historical and inconsistent (e.g., 006-integrations runs
+ * after 010, 007-backfill runs last). The array order reflects the actual
+ * dependency order that must be preserved for correctness.
+ */
+export const MIGRATIONS: MigrationDefinition[] = [
+  {
+    name: '001-initial.sql',
+    up: db => {
+      db.run(loadMigrationSql('001-initial.sql'));
+    },
+  },
+  {
+    name: '002-add-agent-model.sql',
+    up: db => {
+      if (!hasColumn(db, 'agents', 'model')) {
+        db.run(loadMigrationSql('002-add-agent-model.sql'));
+      }
+    },
+  },
+  {
+    name: '003-fix-pull-requests.sql',
+    up: db => {
+      if (!hasColumn(db, 'pull_requests', 'branch_name')) {
+        db.exec(loadMigrationSql('003-fix-pull-requests.sql'));
+      }
+    },
+  },
+  {
+    name: '004-add-messages.sql',
+    up: db => {
+      if (!hasTable(db, 'messages')) {
+        db.run(loadMigrationSql('004-add-messages.sql'));
+      }
+    },
+  },
+  {
+    name: '005-add-agent-last-seen.sql',
+    up: db => {
+      if (!hasColumn(db, 'agents', 'last_seen')) {
+        db.run('ALTER TABLE agents ADD COLUMN last_seen TIMESTAMP');
+      }
+    },
+  },
+  {
+    name: '006-add-agent-worktree.sql',
+    up: db => {
+      if (!hasColumn(db, 'agents', 'worktree_path')) {
+        db.run('ALTER TABLE agents ADD COLUMN worktree_path TEXT');
+      }
+    },
+  },
+  {
+    name: '007-add-indexes.sql',
+    up: db => {
+      db.run('CREATE INDEX IF NOT EXISTS idx_stories_status ON stories(status)');
+      db.run('CREATE INDEX IF NOT EXISTS idx_stories_team_id ON stories(team_id)');
+      db.run(
+        'CREATE INDEX IF NOT EXISTS idx_stories_assigned_agent_id ON stories(assigned_agent_id)'
+      );
+      db.run('CREATE INDEX IF NOT EXISTS idx_stories_requirement_id ON stories(requirement_id)');
+      db.run('CREATE INDEX IF NOT EXISTS idx_agents_team_id ON agents(team_id)');
+      db.run('CREATE INDEX IF NOT EXISTS idx_agents_status ON agents(status)');
+      db.run(
+        'CREATE INDEX IF NOT EXISTS idx_pull_requests_team_status ON pull_requests(team_id, status)'
+      );
+      db.run('CREATE INDEX IF NOT EXISTS idx_pull_requests_story_id ON pull_requests(story_id)');
+      db.run('CREATE INDEX IF NOT EXISTS idx_messages_to_session ON messages(to_session)');
+      db.run('CREATE INDEX IF NOT EXISTS idx_escalations_status ON escalations(status)');
+    },
+  },
+  {
+    name: '008-add-godmode.sql',
+    up: db => {
+      if (!hasColumn(db, 'requirements', 'godmode')) {
+        db.run(loadMigrationSql('008-add-godmode.sql'));
+      }
+    },
+  },
+  {
+    name: '009-add-pr-sync-indexes.sql',
+    up: db => {
+      db.exec(loadMigrationSql('009-add-pr-sync-indexes.sql'));
+    },
+  },
+  {
+    name: '010-add-target-branch.sql',
+    up: db => {
+      if (!hasColumn(db, 'requirements', 'target_branch')) {
+        db.run(loadMigrationSql('010-add-target-branch.sql'));
+      }
+    },
+  },
+  {
+    name: '006-integrations.sql',
+    up: db => {
+      // Add columns to stories table
+      addColumnsIfMissing(db, 'stories', [
+        { name: 'jira_issue_key', type: 'TEXT' },
+        { name: 'jira_issue_id', type: 'TEXT' },
+        { name: 'jira_project_key', type: 'TEXT' },
+        { name: 'jira_subtask_key', type: 'TEXT' },
+        { name: 'jira_subtask_id', type: 'TEXT' },
+      ]);
+
+      // Add columns to requirements table
+      addColumnsIfMissing(db, 'requirements', [
+        { name: 'jira_epic_key', type: 'TEXT' },
+        { name: 'jira_epic_id', type: 'TEXT' },
+      ]);
+
+      // Add column to pull_requests table
+      addColumnsIfMissing(db, 'pull_requests', [{ name: 'jira_issue_key', type: 'TEXT' }]);
+
+      // Create integration_sync table
+      if (!hasTable(db, 'integration_sync')) {
+        db.run(`
+          CREATE TABLE integration_sync (
+            id TEXT PRIMARY KEY,
+            entity_type TEXT NOT NULL CHECK (entity_type IN ('story', 'requirement', 'pull_request')),
+            entity_id TEXT NOT NULL,
+            provider TEXT NOT NULL CHECK (provider IN ('jira', 'github', 'confluence')),
+            external_id TEXT NOT NULL,
+            last_synced_at TIMESTAMP,
+            sync_status TEXT DEFAULT 'pending' CHECK (sync_status IN ('pending', 'synced', 'failed')),
+            error_message TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+          )
+        `);
+        db.run(
+          'CREATE INDEX IF NOT EXISTS idx_integration_sync_entity ON integration_sync(entity_type, entity_id)'
+        );
+        db.run(
+          'CREATE INDEX IF NOT EXISTS idx_integration_sync_provider ON integration_sync(provider, external_id)'
+        );
+        db.run(
+          'CREATE INDEX IF NOT EXISTS idx_integration_sync_status ON integration_sync(sync_status)'
+        );
+        db.run(
+          'CREATE INDEX IF NOT EXISTS idx_integration_sync_last_synced ON integration_sync(last_synced_at)'
+        );
+      }
+    },
+  },
+  {
+    name: '011-generic-integration-fields.sql',
+    up: db => {
+      // Add generic columns to stories table
+      addColumnsIfMissing(db, 'stories', [
+        { name: 'external_issue_key', type: 'TEXT' },
+        { name: 'external_issue_id', type: 'TEXT' },
+        { name: 'external_project_key', type: 'TEXT' },
+        { name: 'external_subtask_key', type: 'TEXT' },
+        { name: 'external_subtask_id', type: 'TEXT' },
+        { name: 'external_provider', type: 'TEXT' },
+      ]);
+
+      // Add generic columns to requirements table
+      addColumnsIfMissing(db, 'requirements', [
+        { name: 'external_epic_key', type: 'TEXT' },
+        { name: 'external_epic_id', type: 'TEXT' },
+        { name: 'external_provider', type: 'TEXT' },
+      ]);
+
+      // Execute UPDATE and CREATE INDEX statements from the SQL file
+      execNonAlterStatements(db, loadMigrationSql('011-generic-integration-fields.sql'));
+    },
+  },
+  {
+    name: '012-sprint-tracking.sql',
+    up: db => {
+      addColumnsIfMissing(db, 'stories', [{ name: 'in_sprint', type: 'INTEGER DEFAULT 0' }]);
+
+      // Execute CREATE INDEX statements from the SQL file
+      execNonAlterStatements(db, loadMigrationSql('012-sprint-tracking.sql'));
+    },
+  },
+  {
+    name: '013-feature-testing-support.sql',
+    up: db => {
+      // 1. Add feature_branch column to requirements
+      if (!hasColumn(db, 'requirements', 'feature_branch')) {
+        db.run(loadMigrationSql('013-feature-testing-support.sql'));
+      }
+
+      // 2. Recreate agents table with updated type CHECK constraint (add 'feature_test')
+      db.run('PRAGMA foreign_keys = OFF');
+
+      db.run(`
+        CREATE TABLE agents_new (
+          id TEXT PRIMARY KEY,
+          type TEXT NOT NULL CHECK (type IN ('tech_lead', 'senior', 'intermediate', 'junior', 'qa', 'feature_test')),
+          team_id TEXT REFERENCES teams(id),
+          tmux_session TEXT,
+          model TEXT,
+          status TEXT DEFAULT 'idle' CHECK (status IN ('idle', 'working', 'blocked', 'terminated')),
+          current_story_id TEXT,
+          memory_state TEXT,
+          last_seen TIMESTAMP,
+          worktree_path TEXT,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+          updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+      `);
+      db.run('INSERT INTO agents_new SELECT * FROM agents');
+      db.run('DROP TABLE agents');
+      db.run('ALTER TABLE agents_new RENAME TO agents');
+
+      // Recreate agents indexes
+      db.run('CREATE INDEX IF NOT EXISTS idx_agents_team_id ON agents(team_id)');
+      db.run('CREATE INDEX IF NOT EXISTS idx_agents_status ON agents(status)');
+
+      // 3. Recreate requirements table with updated status CHECK constraint
+      db.run(`
+        CREATE TABLE requirements_new (
+          id TEXT PRIMARY KEY,
+          title TEXT NOT NULL,
+          description TEXT NOT NULL,
+          submitted_by TEXT DEFAULT 'human',
+          status TEXT DEFAULT 'pending' CHECK (status IN ('pending', 'planning', 'planned', 'in_progress', 'completed', 'sign_off', 'sign_off_failed', 'sign_off_passed')),
+          godmode BOOLEAN DEFAULT 0,
+          target_branch TEXT DEFAULT 'main',
+          feature_branch TEXT,
+          jira_epic_key TEXT,
+          jira_epic_id TEXT,
+          external_epic_key TEXT,
+          external_epic_id TEXT,
+          external_provider TEXT,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+      `);
+      db.run(`
+        INSERT INTO requirements_new (id, title, description, submitted_by, status, godmode, target_branch, feature_branch, jira_epic_key, jira_epic_id, external_epic_key, external_epic_id, external_provider, created_at)
+        SELECT id, title, description, submitted_by, status, godmode, target_branch, feature_branch, jira_epic_key, jira_epic_id, external_epic_key, external_epic_id, external_provider, created_at
+        FROM requirements
+      `);
+      db.run('DROP TABLE requirements');
+      db.run('ALTER TABLE requirements_new RENAME TO requirements');
+
+      db.run('PRAGMA foreign_keys = ON');
+    },
+  },
+  {
+    name: '007-backfill-story-points.sql',
+    up: db => {
+      db.run(`
+        UPDATE stories
+        SET story_points = complexity_score
+        WHERE story_points IS NULL
+          AND complexity_score IS NOT NULL
+      `);
+    },
+  },
+];


### PR DESCRIPTION
## Summary
- Extract migration definitions into typed MIGRATIONS array in src/db/migrations/index.ts
- Replace ~460 lines of repetitive migration blocks with compact loop
- Add helper utilities and getMigrationStatus() for debugging

## Test plan
- [x] Migration runner applies all migrations in order
- [x] Idempotent re-running is safe
- [x] getMigrationStatus reports correct counts
- [x] All 1713 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)