### PR TITLE
feat: add PR close reason logging and hive pr closed command

### DIFF
--- a/src/cli/commands/manager/index.ts
+++ b/src/cli/commands/manager/index.ts
@@ -945,7 +945,9 @@ async function closeStalePRs(ctx: ManagerCheckContext): Promise<void> {
     console.log(chalk.yellow(`  Closed ${closedPRs.length} stale GitHub PR(s):`));
     for (const info of closedPRs) {
       const supersededDesc =
-        info.supersededByPrNumber !== null ? ` (superseded by PR #${info.supersededByPrNumber})` : '';
+        info.supersededByPrNumber !== null
+          ? ` (superseded by PR #${info.supersededByPrNumber})`
+          : '';
       console.log(
         chalk.gray(
           `    PR #${info.closedPrNumber} [${info.storyId}] ${info.branch}${supersededDesc}`

--- a/src/cli/commands/pr.ts
+++ b/src/cli/commands/pr.ts
@@ -596,9 +596,7 @@ prCommand
 
       console.log(chalk.bold('\nRecently Closed PRs:\n'));
       console.log(
-        chalk.gray(
-          `${'Timestamp'.padEnd(22)} ${'Story'.padEnd(20)} ${'PR#'.padEnd(6)} ${'Reason'}`
-        )
+        chalk.gray(`${'Timestamp'.padEnd(22)} ${'Story'.padEnd(20)} ${'PR#'.padEnd(6)} ${'Reason'}`)
       );
       console.log(chalk.gray('─'.repeat(80)));
 
@@ -606,7 +604,9 @@ prCommand
         const ts = new Date(log.timestamp).toLocaleString();
         const story = (log.story_id ?? '-').padEnd(20);
         const metadata =
-          typeof log.metadata === 'string' ? (JSON.parse(log.metadata) as Record<string, unknown>) : (log.metadata as Record<string, unknown> | null) ?? {};
+          typeof log.metadata === 'string'
+            ? (JSON.parse(log.metadata) as Record<string, unknown>)
+            : ((log.metadata as Record<string, unknown> | null) ?? {});
         const prNum = String(metadata?.github_pr_number ?? '-').padEnd(6);
         const supersededBy =
           metadata?.superseded_by_pr_number != null

--- a/src/utils/pr-sync.test.ts
+++ b/src/utils/pr-sync.test.ts
@@ -656,9 +656,7 @@ describe('closeStaleGitHubPRs', () => {
 
     await closeStaleGitHubPRs('/root', db);
 
-    const logs = db.exec(
-      "SELECT message, metadata FROM agent_logs WHERE event_type = 'PR_CLOSED'"
-    );
+    const logs = db.exec("SELECT message, metadata FROM agent_logs WHERE event_type = 'PR_CLOSED'");
     expect(logs.length).toBeGreaterThan(0);
     const message = logs[0].values[0][0] as string;
     expect(message).toContain('#15');

--- a/src/utils/pr-sync.ts
+++ b/src/utils/pr-sync.ts
@@ -382,10 +382,7 @@ export interface ClosedPRInfo {
  * @param db    - sql.js Database instance
  * @returns Array of ClosedPRInfo for each PR that was closed.
  */
-export async function closeStaleGitHubPRs(
-  root: string,
-  db: Database
-): Promise<ClosedPRInfo[]> {
+export async function closeStaleGitHubPRs(root: string, db: Database): Promise<ClosedPRInfo[]> {
   const teams = getAllTeams(db);
   if (teams.length === 0) return [];
 


### PR DESCRIPTION
## Summary

- `closeStaleGitHubPRs()` now returns `ClosedPRInfo[]` instead of a plain count, carrying `storyId`, `closedPrNumber`, `branch`, and `supersededByPrNumber` for each closed PR
- PR_CLOSED log messages now include the superseding PR number (e.g. "superseded by PR #434")
- `closeStalePRs()` in manager prints per-PR detail lines to console (not just a total count)
- New `hive pr closed` command displays recently closed PRs with reasons pulled from `agent_logs`
- 7 new unit tests for `closeStaleGitHubPRs` in `pr-sync.test.ts`

## Story

STORY-TLR-002

## Test plan

- [x] All 1714 existing tests pass
- [x] 7 new `closeStaleGitHubPRs` tests pass (return type, per-PR detail, superseding PR#, gh CLI error tolerance)
- [x] TypeScript compiles clean (`npm run build`)
- [x] Lint passes with 0 errors (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)