### PR TITLE
fix: include target_branch in my-stories output and prompt templates

### DIFF
--- a/src/cli/commands/my-stories.ts
+++ b/src/cli/commands/my-stories.ts
@@ -16,12 +16,15 @@ export const myStoriesCommand = new Command('my-stories')
     await withReadOnlyHiveContext(async ({ db }) => {
       if (!session) {
         // Show all in-progress stories
-        const stories = queryAll<StoryRow & { tmux_session?: string }>(
+        const stories = queryAll<
+          StoryRow & { tmux_session?: string; target_branch?: string }
+        >(
           db.db,
           `
-          SELECT s.*, a.tmux_session
+          SELECT s.*, a.tmux_session, r.target_branch
           FROM stories s
           LEFT JOIN agents a ON s.assigned_agent_id = a.id
+          LEFT JOIN requirements r ON s.requirement_id = r.id
           WHERE s.status IN ('planned', 'in_progress', 'review', 'qa', 'qa_failed')
           ORDER BY s.status, s.created_at
         `
@@ -34,7 +37,7 @@ export const myStoriesCommand = new Command('my-stories')
 
         console.log(chalk.bold('\nActive Stories:\n'));
         for (const story of stories) {
-          printStory(story, story.tmux_session);
+          printStory(story, story.tmux_session, story.target_branch);
         }
         return;
       }
@@ -59,35 +62,37 @@ export const myStoriesCommand = new Command('my-stories')
         process.exit(1);
       }
 
-      let stories: StoryRow[];
+      let stories: (StoryRow & { target_branch?: string })[];
       if (options.all && agent.team_id) {
         // Show all team stories
-        stories = queryAll<StoryRow>(
+        stories = queryAll<StoryRow & { target_branch?: string }>(
           db.db,
           `
-          SELECT * FROM stories
-          WHERE team_id = ?
+          SELECT s.*, r.target_branch FROM stories s
+          LEFT JOIN requirements r ON s.requirement_id = r.id
+          WHERE s.team_id = ?
           ORDER BY
-            CASE status
+            CASE s.status
               WHEN 'in_progress' THEN 1
               WHEN 'planned' THEN 2
               WHEN 'review' THEN 3
               WHEN 'qa' THEN 4
               ELSE 5
             END,
-            complexity_score DESC
+            s.complexity_score DESC
         `,
           [agent.team_id]
         );
       } else {
         // Show only assigned active stories (exclude merged/terminal states)
-        stories = queryAll<StoryRow>(
+        stories = queryAll<StoryRow & { target_branch?: string }>(
           db.db,
           `
-          SELECT * FROM stories
-          WHERE assigned_agent_id = ?
-          AND status IN ('planned', 'in_progress', 'review', 'qa', 'qa_failed', 'pr_submitted')
-          ORDER BY created_at
+          SELECT s.*, r.target_branch FROM stories s
+          LEFT JOIN requirements r ON s.requirement_id = r.id
+          WHERE s.assigned_agent_id = ?
+          AND s.status IN ('planned', 'in_progress', 'review', 'qa', 'qa_failed', 'pr_submitted')
+          ORDER BY s.created_at
         `,
           [agent.id]
         );
@@ -106,7 +111,7 @@ export const myStoriesCommand = new Command('my-stories')
       console.log(chalk.bold(`\nStories for ${session}${options.all ? ' (all team)' : ''}:\n`));
 
       for (const story of stories) {
-        printStory(story);
+        printStory(story, undefined, story.target_branch);
       }
     });
   });
@@ -308,11 +313,14 @@ myStoriesCommand
     }
   );
 
-function printStory(story: StoryRow, assignedSession?: string): void {
+function printStory(story: StoryRow, assignedSession?: string, targetBranch?: string): void {
   console.log(chalk.cyan(`[${story.id}]`) + ` ${story.title}`);
   console.log(
     `  Status: ${story.status.toUpperCase()} | Complexity: ${story.complexity_score || '?'}`
   );
+  if (targetBranch && targetBranch !== 'main') {
+    console.log(`  Target branch: ${targetBranch}`);
+  }
   if (assignedSession) {
     console.log(`  Assigned: ${assignedSession}`);
   }

--- a/src/orchestrator/prompt-templates.ts
+++ b/src/orchestrator/prompt-templates.ts
@@ -68,7 +68,9 @@ hive my-stories ${sessionName}
 Mark story complete:
 \`\`\`bash
 hive my-stories complete <story-id>
-\`\`\``;
+\`\`\`
+
+**IMPORTANT — Target Branch:** If your stories target a branch other than \`main\`, the target branch is shown in the \`hive my-stories\` output. After context compaction, always re-run \`hive my-stories ${sessionName}\` to confirm which branch to target for PRs and merges. Do NOT assume \`main\` — use the target branch displayed in the output.`;
 }
 
 function prSubmissionSection(sessionName: string, targetBranch: string): string {


### PR DESCRIPTION
## Summary
- Added `target_branch` from the parent requirement to all `hive my-stories` query outputs via LEFT JOIN with the requirements table
- Updated `printStory()` to display target branch when it differs from `main`
- Added instruction in prompt templates' story discovery section telling agents to re-run `hive my-stories` after context compaction to confirm their target branch

## Context
When agents work on feature branch development (target_branch != main), the target branch is only embedded in the initial prompt at spawn time. After Claude Code compacts context (token limit), agents lose which branch to target for PRs and fall back to assuming main.

STORY-B6336528

## Test plan
- [x] All 1714 existing tests pass
- [x] TypeScript compiles with no errors
- [ ] Verify `hive my-stories` shows target branch for stories with non-main requirement target_branch
- [ ] Verify agents can recover target branch info after compaction by re-running `hive my-stories`

🤖 Generated with [Claude Code](https://claude.com/claude-code)