### PR TITLE
fix: include target_branch in my-stories output for post-compaction recovery

### DIFF
--- a/src/orchestrator/prompt-templates.ts
+++ b/src/orchestrator/prompt-templates.ts
@@ -68,7 +68,10 @@ hive my-stories ${sessionName}
 Mark story complete:
 \`\`\`bash
 hive my-stories complete <story-id>
-\`\`\``;
+\`\`\`
+
+### Target Branch Recovery
+If your context has been compacted and you are unsure which branch to target for PRs, run \`hive my-stories ${sessionName}\` — the output includes the target branch for each story (when it differs from main). Always use this to verify the correct base branch before creating PRs.`;
 }
 
 function prSubmissionSection(sessionName: string, targetBranch: string): string {


### PR DESCRIPTION
## Summary
- JOINs stories with requirements table in all `my-stories` SQL queries to fetch `target_branch`
- Displays `Target: <branch>` in story output when target_branch differs from `main`
- Adds "Target Branch Recovery" section to prompt-templates instructing agents to re-run `hive my-stories` after context compaction to recover target branch info

Closes #440

## Test plan
- [x] All 1714 existing tests pass
- [x] TypeScript compiles cleanly
- [ ] Verify my-stories output shows target branch for stories with non-main target_branch
- [ ] Verify agents can recover target branch info after context compaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)