### PR TITLE
fix: skip auto-closing PRs targeting non-configured base branch

### DIFF
--- a/src/cli/commands/manager/index.ts
+++ b/src/cli/commands/manager/index.ts
@@ -1200,12 +1200,16 @@ async function closeStalePRs(ctx: ManagerCheckContext): Promise<void> {
 
   // Phase 2: GitHub CLI calls (no lock)
   const GH_CLI_TIMEOUT_MS = 30000;
+  const baseBranch = ctx.config.github?.base_branch ?? 'main';
   const closed: import('../../../utils/pr-sync.js').ClosedPRInfo[] = [];
 
   for (const team of teamInfos) {
     try {
       const openGHPRs = await fetchOpenGitHubPRs(team.repoDir);
       for (const ghPR of openGHPRs) {
+        // Skip PRs that don't target the configured base branch
+        if (ghPR.baseRefName !== baseBranch) continue;
+
         const storyId = extractStoryIdFromBranch(ghPR.headRefName);
         if (!storyId) continue;
         const prsForStory = prsByStory.get(storyId);


### PR DESCRIPTION
## Summary

- Adds `baseRefName` to `GitHubPR` interface and `fetchOpenGitHubPRs()` query
- Both `closeStalePRs()` (manager/index.ts) and `closeStaleGitHubPRs()` (pr-sync.ts) now skip PRs that don't target `config.github.base_branch`
- Adds `baseBranch` parameter (default: `'main'`) to `closeStaleGitHubPRs()`

## Root Cause

The `closeStalePRs()` and `closeStaleGitHubPRs()` functions were closing GitHub PRs solely based on whether their PR number appeared in the local merge queue, without checking if the PR targeted the configured base branch. When `github.base_branch` was set to something other than `main`, valid PRs targeting that branch were incorrectly auto-closed.

## Test Plan

- [x] `closeStaleGitHubPRs()` skips PRs targeting non-configured base branch
- [x] `closeStaleGitHubPRs()` closes stale PRs when base branch matches configured one (including non-main)
- [x] `closeStaleGitHubPRs()` ignores PRs targeting `main` when configured base is a feature branch
- [x] All existing tests updated with `baseRefName` in mock data
- [x] All 1717 tests pass, type-check clean

Story: STORY-BD0222D9
Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)