### PR TITLE
fix: handle plain text acceptance_criteria in Jira sync

### DIFF
--- a/src/integrations/jira/stories.test.ts
+++ b/src/integrations/jira/stories.test.ts
@@ -93,16 +93,34 @@ describe('Jira Story Creation', () => {
       expect(result).toEqual(['criterion 1', 'criterion 2']);
     });
 
-    it('should return empty array for malformed JSON and log warning', () => {
-      const warnSpy = vi.spyOn(logger, 'warn');
+    it('should parse malformed JSON as plain text', () => {
       const malformedJson = '{"invalid json';
       const result = safelyParseAcceptanceCriteria(malformedJson, 'story-123');
+      expect(result).toEqual(['{"invalid json']);
+    });
 
-      expect(result).toEqual([]);
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to parse acceptance_criteria for story story-123')
-      );
-      warnSpy.mockRestore();
+    it('should parse plain text markdown bullet list', () => {
+      const plainText = '- criterion 1\n- criterion 2\n- criterion 3';
+      const result = safelyParseAcceptanceCriteria(plainText, 'story-123');
+      expect(result).toEqual(['criterion 1', 'criterion 2', 'criterion 3']);
+    });
+
+    it('should parse plain text with asterisk bullets', () => {
+      const plainText = '* criterion A\n* criterion B';
+      const result = safelyParseAcceptanceCriteria(plainText, 'story-123');
+      expect(result).toEqual(['criterion A', 'criterion B']);
+    });
+
+    it('should parse plain text without bullet prefixes', () => {
+      const plainText = 'criterion 1\ncriterion 2';
+      const result = safelyParseAcceptanceCriteria(plainText, 'story-123');
+      expect(result).toEqual(['criterion 1', 'criterion 2']);
+    });
+
+    it('should filter empty lines when parsing plain text', () => {
+      const plainText = '- criterion 1\n\n- criterion 2\n\n';
+      const result = safelyParseAcceptanceCriteria(plainText, 'story-123');
+      expect(result).toEqual(['criterion 1', 'criterion 2']);
     });
 
     it('should return empty array for non-array JSON and log warning', () => {

--- a/src/integrations/jira/stories.ts
+++ b/src/integrations/jira/stories.ts
@@ -76,6 +76,7 @@ function acceptanceCriteriaToAdf(description: string, criteria: string[]): AdfDo
 /**
  * Safely parse acceptance_criteria JSON string.
  * Returns empty array if parsing fails or if result is not an array.
+ * Falls back to plain-text parsing (e.g. markdown bullet lists) if JSON parsing fails.
  * Exported for testing.
  */
 export function safelyParseAcceptanceCriteria(
@@ -95,11 +96,13 @@ export function safelyParseAcceptanceCriteria(
       return [];
     }
     return parsed as string[];
-  } catch (err) {
-    logger.warn(
-      `Failed to parse acceptance_criteria for story ${storyId}: ${err instanceof Error ? err.message : String(err)}`
-    );
-    return [];
+  } catch {
+    // Not valid JSON — treat as plain text (e.g. markdown bullet list)
+    const lines = acceptanceCriteriaJson
+      .split('\n')
+      .map(line => line.replace(/^[-*]\s*/, '').trim())
+      .filter(line => line.length > 0);
+    return lines;
   }
 }
 


### PR DESCRIPTION
## Summary
- `safelyParseAcceptanceCriteria()` in `src/integrations/jira/stories.ts` failed with "No number after minus sign in JSON" when `acceptance_criteria` was stored as a plain-text markdown bullet list
- Added a plain-text fallback in the catch block: splits on newlines, strips leading `- ` / `* ` bullet prefixes, filters empty lines
- Added 5 new tests covering markdown dash bullets, asterisk bullets, plain newline text, and empty-line filtering

Story: STR-HIVE-002
GitHub Issue: #453

## Test plan
- [x] New unit tests for markdown bullet list parsing (`- item`, `* item`)
- [x] New unit test for plain newline-separated text (no bullets)
- [x] New unit test for empty-line filtering
- [x] Updated existing "malformed JSON" test to reflect new plain-text fallback behaviour
- [x] All 1722 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)