### PR TITLE
feat: generate descriptive Jira epic titles using AI

### DIFF
--- a/src/integrations/jira/stories.test.ts
+++ b/src/integrations/jira/stories.test.ts
@@ -9,15 +9,17 @@ import { TokenStore } from '../../auth/token-store.js';
 import type { JiraConfig } from '../../config/schema.js';
 import { createStory } from '../../db/queries/stories.js';
 import { createTestDatabase } from '../../db/queries/test-helpers.js';
+import { AnthropicProvider } from '../../llm/anthropic.js';
 import { generateTechLeadJiraInstructions } from '../../orchestrator/prompt-templates.js';
 import * as logger from '../../utils/logger.js';
 import { JiraClient } from './client.js';
 import { createIssue } from './issues.js';
-import { safelyParseAcceptanceCriteria, syncStoryToJira } from './stories.js';
+import { generateEpicTitle, safelyParseAcceptanceCriteria, syncStoryToJira } from './stories.js';
 
 // Mock Jira client and issues
 vi.mock('./client.js');
 vi.mock('./issues.js');
+vi.mock('../../llm/anthropic.js');
 vi.mock('./sprints.js', () => ({
   getActiveSprintForProject: vi.fn().mockResolvedValue(null),
   moveIssuesToSprint: vi.fn().mockResolvedValue(undefined),
@@ -73,6 +75,121 @@ describe('Jira Story Creation', () => {
     it('should note sync failures do not block pipeline', () => {
       const result = generateTechLeadJiraInstructions('HIVE', 'https://mycompany.atlassian.net');
       expect(result).toContain('do NOT block the pipeline');
+    });
+  });
+
+  describe('generateEpicTitle', () => {
+    beforeEach(() => {
+      vi.mocked(AnthropicProvider).mockClear();
+    });
+
+    it('should return AI-generated title when LLM call succeeds', async () => {
+      const mockComplete = vi.fn().mockResolvedValue({
+        content: 'User Authentication with OAuth2 Integration',
+        stopReason: 'end_turn',
+        usage: { inputTokens: 50, outputTokens: 10 },
+      });
+      vi.mocked(AnthropicProvider).mockImplementation(
+        () => ({ complete: mockComplete, name: 'anthropic' }) as any
+      );
+
+      const result = await generateEpicTitle(
+        'Build auth system with OAuth2',
+        'Allow users to log in with Google and GitHub accounts'
+      );
+
+      expect(result).toBe('User Authentication with OAuth2 Integration');
+      expect(mockComplete).toHaveBeenCalledOnce();
+    });
+
+    it('should fall back to original title when LLM call throws', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn');
+      vi.mocked(AnthropicProvider).mockImplementation(
+        () =>
+          ({
+            complete: vi.fn().mockRejectedValue(new Error('API key missing')),
+            name: 'anthropic',
+          }) as any
+      );
+
+      const result = await generateEpicTitle('Raw prompt title', 'Some description');
+
+      expect(result).toBe('Raw prompt title');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to generate epic title via AI')
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('should fall back to original title when LLM returns empty content', async () => {
+      vi.mocked(AnthropicProvider).mockImplementation(
+        () =>
+          ({
+            complete: vi.fn().mockResolvedValue({
+              content: '   ',
+              stopReason: 'end_turn',
+              usage: { inputTokens: 50, outputTokens: 1 },
+            }),
+            name: 'anthropic',
+          }) as any
+      );
+
+      const result = await generateEpicTitle('Original Title', 'Description');
+
+      expect(result).toBe('Original Title');
+    });
+
+    it('should strip surrounding quotes from generated title', async () => {
+      vi.mocked(AnthropicProvider).mockImplementation(
+        () =>
+          ({
+            complete: vi.fn().mockResolvedValue({
+              content: '"User Management System"',
+              stopReason: 'end_turn',
+              usage: { inputTokens: 50, outputTokens: 8 },
+            }),
+            name: 'anthropic',
+          }) as any
+      );
+
+      const result = await generateEpicTitle('user management', 'Manage users');
+
+      expect(result).toBe('User Management System');
+    });
+
+    it('should truncate generated title to 255 characters', async () => {
+      const longTitle = 'A'.repeat(300);
+      vi.mocked(AnthropicProvider).mockImplementation(
+        () =>
+          ({
+            complete: vi.fn().mockResolvedValue({
+              content: longTitle,
+              stopReason: 'end_turn',
+              usage: { inputTokens: 50, outputTokens: 300 },
+            }),
+            name: 'anthropic',
+          }) as any
+      );
+
+      const result = await generateEpicTitle('title', 'desc');
+
+      expect(result.length).toBe(255);
+    });
+
+    it('should handle empty description gracefully', async () => {
+      const mockComplete = vi.fn().mockResolvedValue({
+        content: 'Generated Title',
+        stopReason: 'end_turn',
+        usage: { inputTokens: 20, outputTokens: 5 },
+      });
+      vi.mocked(AnthropicProvider).mockImplementation(
+        () => ({ complete: mockComplete, name: 'anthropic' }) as any
+      );
+
+      const result = await generateEpicTitle('title hint', '');
+
+      expect(result).toBe('Generated Title');
+      expect(mockComplete).toHaveBeenCalledOnce();
     });
   });
 

--- a/src/integrations/jira/stories.ts
+++ b/src/integrations/jira/stories.ts
@@ -8,6 +8,7 @@ import type { StoryRow } from '../../db/client.js';
 import { createSyncRecord, getSyncRecordByEntity } from '../../db/queries/integration-sync.js';
 import { updateRequirement, type RequirementRow } from '../../db/queries/requirements.js';
 import { getStoryById, getStoryDependencies, updateStory } from '../../db/queries/stories.js';
+import { AnthropicProvider } from '../../llm/anthropic.js';
 import * as logger from '../../utils/logger.js';
 import { JiraClient } from './client.js';
 import { createIssue, createIssueLink } from './issues.js';
@@ -46,6 +47,49 @@ function textToAdf(text: string): AdfDocument {
   }));
 
   return { version: 1, type: 'doc', content };
+}
+
+/**
+ * Generate a concise, descriptive Jira epic title using an AI model.
+ * Falls back to the original title if generation fails or produces an empty result.
+ * Exported for testing.
+ */
+export async function generateEpicTitle(title: string, description: string): Promise<string> {
+  try {
+    const provider = new AnthropicProvider({
+      model: 'claude-haiku-4-5-20251001',
+      maxTokens: 50,
+      temperature: 0.3,
+    });
+
+    const truncatedDescription = description ? description.substring(0, 500) : '';
+    const prompt = `Generate a concise, descriptive Jira epic title (maximum 100 characters) for a software feature.
+
+Title hint: ${title}
+Description: ${truncatedDescription}
+
+Rules:
+- Return ONLY the title text, no explanation or quotes
+- Be specific and descriptive about what the feature does
+- Use title case
+- Maximum 100 characters`;
+
+    const result = await provider.complete([{ role: 'user', content: prompt }], {
+      maxTokens: 50,
+      timeoutMs: 10000,
+    });
+
+    const generated = result.content.trim().replace(/^["']|["']$/g, '');
+    if (generated.length > 0) {
+      return generated.substring(0, 255);
+    }
+  } catch (err) {
+    logger.warn(
+      `Failed to generate epic title via AI, using original: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+
+  return title;
 }
 
 /**
@@ -200,10 +244,11 @@ export async function syncRequirementToJira(
     // Create a new Jira Epic
     let epic: CreateIssueResponse | null = null;
     try {
+      const epicTitle = await generateEpicTitle(requirement.title, requirement.description);
       epic = await createIssue(client, {
         fields: {
           project: { key: config.project_key },
-          summary: requirement.title,
+          summary: epicTitle,
           issuetype: { name: 'Epic' },
           description: textToAdf(requirement.description),
           labels,


### PR DESCRIPTION
## Summary
- Adds `generateEpicTitle()` function in `src/integrations/jira/stories.ts` that calls Claude Haiku to generate a concise, descriptive Jira epic summary from the requirement title and description
- Updates `syncRequirementToJira` to use `generateEpicTitle` instead of raw `requirement.title` (line 206) when creating Jira epics
- Falls back gracefully to original title on LLM failure/timeout so existing behavior is preserved

## Test plan
- [ ] 6 new unit tests cover: AI success, LLM failure fallback, empty content fallback, quote stripping, 255-char truncation, empty description input
- [ ] All 1740 existing tests still pass
- [ ] TypeScript builds without errors

Story: STR-HIVE-005

🤖 Generated with [Claude Code](https://claude.com/claude-code)