### PR TITLE
fix: hive reliability improvements from Mini Marty project

### DIFF
--- a/src/cli/commands/manager/auto-assignment.ts
+++ b/src/cli/commands/manager/auto-assignment.ts
@@ -9,19 +9,19 @@ function verboseLog(ctx: Pick<ManagerCheckContext, 'verbose'>, message: string):
   console.log(chalk.gray(`  [verbose] ${message}`));
 }
 
-async function getPlannedUnassignedStoryCount(ctx: ManagerCheckContext): Promise<number> {
+async function getAssignableUnassignedStoryCount(ctx: ManagerCheckContext): Promise<number> {
   return ctx.withDb(async db => {
     const rows = queryAll<{ count: number }>(
       db.db,
-      "SELECT COUNT(*) as count FROM stories WHERE status = 'planned' AND assigned_agent_id IS NULL"
+      "SELECT COUNT(*) as count FROM stories WHERE status IN ('planned', 'qa_failed') AND assigned_agent_id IS NULL"
     );
     return rows[0]?.count || 0;
   });
 }
 
 export async function autoAssignPlannedStories(ctx: ManagerCheckContext): Promise<void> {
-  const plannedUnassigned = await getPlannedUnassignedStoryCount(ctx);
-  verboseLog(ctx, `autoAssignPlannedStories: plannedUnassigned=${plannedUnassigned}`);
+  const plannedUnassigned = await getAssignableUnassignedStoryCount(ctx);
+  verboseLog(ctx, `autoAssignPlannedStories: assignableUnassigned=${plannedUnassigned}`);
 
   if (plannedUnassigned === 0) {
     return;

--- a/src/cli/commands/manager/index.ts
+++ b/src/cli/commands/manager/index.ts
@@ -1558,7 +1558,33 @@ async function recoverStaleReviewingPRs(ctx: ManagerCheckContext): Promise<void>
       const state = parsed.state?.toUpperCase();
       const url = parsed.url || null;
 
-      if (state === 'OPEN') continue;
+      if (state === 'OPEN') {
+        // PR is still open on GitHub but stale in 'reviewing' — the QA agent
+        // may have missed the original nudge. Re-nudge if QA agent is idle.
+        if (candidate.reviewedBy) {
+          const qaAgent = ctx.agentsBySessionName.get(candidate.reviewedBy);
+          if (qaAgent && qaAgent.status === 'idle') {
+            const githubLine = candidate.repoSlug
+              ? `\n# GitHub: https://github.com/${candidate.repoSlug}/pull/${candidate.githubPrNumber}`
+              : '';
+            await sendManagerNudge(
+              ctx,
+              candidate.reviewedBy,
+              `# [REMINDER] You are assigned PR review ${candidate.id} (${candidate.storyId || 'no-story'}).${githubLine}
+# This PR has been waiting for review. Execute now:
+#   hive pr show ${candidate.id}
+#   hive pr approve ${candidate.id}
+# or reject:
+#   hive pr reject ${candidate.id} -r "reason"`
+            );
+            verboseLogCtx(
+              ctx,
+              `recoverStaleReviewingPRs: re-nudged idle QA ${candidate.reviewedBy} for stale pr=${candidate.id}`
+            );
+          }
+        }
+        continue;
+      }
       if (state === 'MERGED') {
         mergedResults.push({
           candidate,
@@ -1879,10 +1905,19 @@ async function scanAgentSessions(ctx: ManagerCheckContext): Promise<void> {
   // Phase 2: Per-session processing (tmux/AI outside lock, DB writes under brief locks)
   for (const session of ctx.hiveSessions) {
     if (session.name === 'hive-manager') continue;
-    activeSessionNames.add(session.name);
 
     const agent = ctx.agentsBySessionName.get(session.name);
-    const agentCliTool = (agent?.cli_tool || 'claude') as CLITool;
+
+    // Skip sessions not registered in our DB (cross-project sessions).
+    // This prevents escalation noise from sessions belonging to other
+    // teams/projects sharing the same tmux server.
+    if (!agent) {
+      verboseLogCtx(ctx, `Skipping ${session.name}: no agent registered in DB (cross-project)`);
+      continue;
+    }
+
+    activeSessionNames.add(session.name);
+    const agentCliTool = (agent.cli_tool || 'claude') as CLITool;
     const safetyMode = getAgentSafetyMode(ctx.config, agent);
     verboseLogCtx(
       ctx,

--- a/src/tmux/manager.ts
+++ b/src/tmux/manager.ts
@@ -266,14 +266,25 @@ export async function sendToTmuxSession(
     await new Promise(resolve => setTimeout(resolve, CLEAR_INPUT_DELAY_MS));
   }
 
-  // For single-line text, use send-keys with literal flag then Enter separately.
-  // '--' signals end of options, preventing text starting with '-' from being parsed as flags.
-  //
-  // NOTE: Multi-line initial prompts should be passed via spawnTmuxSession's
-  // initialPrompt option, which writes to a temp file and uses $(cat ...) to
-  // deliver the prompt as a CLI positional argument. This function is only for
-  // single-line runtime messages (nudges, commands, etc).
-  await execa('tmux', ['send-keys', '-t', sessionName, '-l', '--', text]);
+  const isMultiLine = text.includes('\n');
+
+  if (isMultiLine) {
+    // Multi-line text: write to temp file and paste via $(cat ...) to avoid
+    // the [Pasted text #N] buffering issue in Claude CLI. The shell expands
+    // $(cat file) into a single argument, bypassing tmux's paste-buffer handling.
+    const tempFile = join(
+      tmpdir(),
+      `hive-nudge-${Date.now()}-${sessionName.replace(/[^a-zA-Z0-9-]/g, '_')}.txt`
+    );
+    writeFileSync(tempFile, text, 'utf-8');
+    const catCmd = `$(cat ${tempFile})`;
+    await execa('tmux', ['send-keys', '-t', sessionName, '-l', '--', catCmd]);
+  } else {
+    // Single-line: use send-keys with literal flag directly.
+    // '--' signals end of options, preventing text starting with '-' from being parsed as flags.
+    await execa('tmux', ['send-keys', '-t', sessionName, '-l', '--', text]);
+  }
+
   // Send Enter as a key event (C-m = carriage return = Enter) to ensure prompt receives it
   await execa('tmux', ['send-keys', '-t', sessionName, 'C-m']);
 }


### PR DESCRIPTION
## Summary
- **IMP-010**: Skip cross-project tmux sessions in `scanAgentSessions` — prevents escalation noise from other teams sharing the tmux server
- **IMP-004**: Fix multi-line nudge delivery via temp file + `$(cat file)` approach to avoid `[Pasted text]` buffering in Claude CLI
- **IMP-008**: Re-nudge idle QA agents when PRs are stale in 'reviewing' but still OPEN on GitHub
- **IMP-009**: Include `qa_failed` stories in auto-assignment count check so idle agents get reassigned after QA rejection
- **IMP-005**: Confirmed already fixed by IMP-001 (idle-only filter + local snapshot update)

All issues were discovered during the Mini Marty 12-story full-stack build.

## Test plan
- [ ] Run existing test suite (`vitest run`)
- [ ] Verify manager daemon starts without errors
- [ ] Test multi-line nudge delivery in a tmux session
- [ ] Confirm cross-project sessions are skipped in verbose mode
- [ ] Verify auto-assignment picks up qa_failed stories