### PR TITLE
fix: reset created_at on tech lead restart to prevent restart loop

### DIFF
--- a/src/cli/commands/manager/index.ts
+++ b/src/cli/commands/manager/index.ts
@@ -3267,6 +3267,7 @@ async function restartStaleTechLead(ctx: ManagerCheckContext): Promise<void> {
       });
       updateAgent(db.db, techLead.id, {
         status: 'working',
+        createdAt: new Date().toISOString(),
       });
       db.save();
     });

--- a/src/db/queries/agents.test.ts
+++ b/src/db/queries/agents.test.ts
@@ -316,6 +316,19 @@ describe('agents queries', () => {
 
       expect(updated?.tmux_session).toBeNull();
     });
+
+    it('should reset created_at when createdAt is provided', () => {
+      const agent = createAgent(db, { type: 'tech_lead', teamId });
+      const newCreatedAt = new Date(Date.now() + 60_000).toISOString();
+
+      const updated = updateAgent(db, agent.id, {
+        status: 'working',
+        createdAt: newCreatedAt,
+      });
+
+      expect(updated?.created_at).toBe(newCreatedAt);
+      expect(updated?.status).toBe('working');
+    });
   });
 
   describe('deleteAgent', () => {

--- a/src/db/queries/agents.ts
+++ b/src/db/queries/agents.ts
@@ -23,6 +23,7 @@ export interface UpdateAgentInput {
   currentStoryId?: string | null;
   memoryState?: string | null;
   worktreePath?: string | null;
+  createdAt?: string;
 }
 
 export function createAgent(db: Database, input: CreateAgentInput): AgentRow {
@@ -113,6 +114,10 @@ export function updateAgent(
   if (input.worktreePath !== undefined) {
     updates.push('worktree_path = ?');
     values.push(input.worktreePath);
+  }
+  if (input.createdAt !== undefined) {
+    updates.push('created_at = ?');
+    values.push(input.createdAt);
   }
 
   if (updates.length === 1) {


### PR DESCRIPTION
## Summary

- Bug: `restartStaleTechLead()` checked `agent.created_at` to detect a stale tech lead but never reset it after restarting, causing the manager to restart the tech lead on every subsequent check cycle.
- Fix: Added `createdAt` field to `UpdateAgentInput` and handle it in `updateAgent()`. After a successful tech lead restart, pass `createdAt: new Date().toISOString()` so the next check cycle sees a fresh timestamp.
- Added a unit test in `src/db/queries/agents.test.ts` verifying that `updateAgent` correctly persists a provided `createdAt` value.

**Story:** STORY-OHQD-001

## Files changed

- `src/db/queries/agents.ts` — add `createdAt` to `UpdateAgentInput`, handle `created_at` column in `updateAgent()`
- `src/cli/commands/manager/index.ts` — reset `createdAt` in the `updateAgent()` call after tech lead restart
- `src/db/queries/agents.test.ts` — new test for `createdAt` reset behaviour

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] New test `should reset created_at when createdAt is provided` passes